### PR TITLE
Introduce rust-toolchain.toml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,6 @@ jobs:
           rustup default stable
           rustup update nightly
           rustup update stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Check Build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [vNext]
+
+### Added
+
+- `rust-toolchain.toml` as a single source of truth on toolchain requirements (except Nix builder)
+
 ## [3.0.0]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     export PATH=$PATH:$HOME/.cargo/bin && \
     scripts/init.sh && \
-    cargo +nightly-2022-07-27 build --$PROFILE
+    cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 FROM phusion/baseimage:0.11

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -21,4 +21,4 @@ RUN apt-get update && \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     export PATH=$PATH:$HOME/.cargo/bin && \
     scripts/init.sh && \
-    TRYBUILD=overwrite cargo +nightly-2022-07-27 test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path cli/Cargo.toml
+    TRYBUILD=overwrite cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path cli/Cargo.toml

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2022-07-27"
+components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-07-27"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2022-07-27"
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
The PR introduces `rust-toolchain.toml` file to have a single source of truth on the Rust toolchain for the project. Having `rust-toolchain.toml` simplifies development environment setup and mitigates build instructions because they should not specify toolchain parameters explicitly anymore.