### PR TITLE
test(commands): experimenting with running options

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -38,7 +38,7 @@ impl SubstrateCli for Cli {
 			#[cfg(feature = "cere-dev-native")]
 			"cere-devnet" => Box::new(cere_service::chain_spec::cere_devnet_config()?),
 			#[cfg(feature = "cere-dev-native")]
-			"dev" => Box::new(cere_service::chain_spec::cere_dev_development_config()?),
+			"cere-dev" | "dev" => Box::new(cere_service::chain_spec::cere_dev_development_config()?),
 			#[cfg(feature = "cere-dev-native")]
             "local" => Box::new(cere_service::chain_spec::cere_dev_local_testnet_config()?),
 			path => {

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -650,7 +650,8 @@ impl IdentifyVariant for Box<dyn sc_service::ChainSpec> {
 		// Works for "cere-devnet" and "dev" arms in the load_spec(...) call.
 		// If you are specifying a customSpecRaw.json for "path" arm along with the "--force-cere-dev" flag,
 		// make sure your spec has a compatible "id" field to satisfy this condition
-		self.id().starts_with("cere_dev")
+		println!("self.id = {:?}", self.id());
+		self.id().starts_with("This is intentionally broken condition, just to see how the \"cere-dev\" | \"dev\" arm will work with different options")
 	}
 }
 


### PR DESCRIPTION
At the moment we have unexpected behaviour while running a local node in development mode.

In this test, I added 2 patterns (`"cere-dev" | "dev"`) in one arm, that involves execution of the same expression.
Also, I intentionally broke the condition that checks chain specification id, just to see how the node will start with different options.

Here are results, that I'm getting on my local:

If I start the node as:
`./target/debug/cere --chain=cere-dev --force-authoring --rpc-cors=all --alice --base-path=/home/yahortsaryk/data/started-with-custom-cere-dev-chain`
it will run it with the **CereDev** runtime (I **can** see the `ddcStaking` pallet in the web explorer).

If I start the node as:
`./target/debug/cere --dev --base-path=/home/yahortsaryk/data/started-with-default-dev-flag`
it will run it with the **Cere** runtime (I **can not** see the `ddcStaking` pallet in the web explorer)

It is very weird, as both runs call the same `cere_dev_development_config()` method, that provides the same chain specification (with id = `cere_dev`).

It means, that we either do not fully understand behaviour of the default `--dev` flag, or our/polkadot's codebase has a bug. This needs to be investigated

