### PR TITLE
Fixed bond size for DDC Staking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `rust-toolchain.toml` as a single source of truth on toolchain requirements (except Nix builder)
 - Cere Dev Local Testnet config
+- New `set_staking_configs` call in `pallet-ddc-staking` to allow to set DDC Staking bond size by the authority
+
+### Changed
+
+- `pallet-ddc-staking` now requires one fixed size bond for both `Storage` and `Edge` roles instead of the bond limited by the lower boundary only
 
 ## [3.0.0]
 

--- a/pallets/ddc-staking/src/benchmarking.rs
+++ b/pallets/ddc-staking/src/benchmarking.rs
@@ -78,9 +78,8 @@ benchmarks! {
 		let controller = create_funded_user::<T>("controller", USER_SEED, 100);
 		let controller_lookup: <T::Lookup as StaticLookup>::Source
 			= T::Lookup::unlookup(controller.clone());
-		let amount = T::Currency::minimum_balance() * 10u32.into(); 
 		whitelist_account!(stash);
-	}: _(RawOrigin::Signed(stash.clone()), controller_lookup, amount)
+	}: _(RawOrigin::Signed(stash.clone()), controller_lookup)
 	verify {
 		assert!(Bonded::<T>::contains_key(stash));
 		assert!(Ledger::<T>::contains_key(controller));
@@ -101,12 +100,11 @@ benchmarks! {
 		let stash = scenario.origin_stash1.clone();
 		let controller = scenario.origin_controller1.clone();
 		// unbond half of initial balance
-		let amount = origin_balance / 2u32.into(); 
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
 		let original_bonded: BalanceOf<T> = ledger.active;
 
 		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller.clone()), amount)
+	}: _(RawOrigin::Signed(controller.clone()))
 	verify {
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
 		let new_bonded: BalanceOf<T> = ledger.active;
@@ -115,8 +113,7 @@ benchmarks! {
 
 	withdraw_unbonded {
 		let (stash, controller) = create_stash_controller::<T>(0, 100)?;
-		let amount = T::Currency::minimum_balance() * 5u32.into(); // Half of total
-		DddcStaking::<T>::unbond(RawOrigin::Signed(controller.clone()).into(), amount)?;
+		DddcStaking::<T>::unbond(RawOrigin::Signed(controller.clone()).into())?;
 		CurrentEra::<T>::put(EraIndex::max_value()); 
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
 		let original_total: BalanceOf<T> = ledger.total;
@@ -152,7 +149,7 @@ benchmarks! {
 		// clean up any existing state.
 		clear_storages_and_edges::<T>();
 
-		let origin_balance = MinStorageBond::<T>::get().max(T::Currency::minimum_balance());
+		let origin_balance = BondSize::<T>::get().max(T::Currency::minimum_balance());
 
 		let scenario = AccountsScenario::<T>::new(origin_balance)?;
 		let controller = scenario.origin_controller1.clone();

--- a/pallets/ddc-staking/src/benchmarking.rs
+++ b/pallets/ddc-staking/src/benchmarking.rs
@@ -86,32 +86,6 @@ benchmarks! {
 		assert!(Ledger::<T>::contains_key(controller));
 	}
 
-	bond_extra {
-		// clean up any existing state.
-		clear_storages_and_edges::<T>();
-
-		let origin_balance = MinStorageBond::<T>::get().max(T::Currency::minimum_balance()); 
-
-		let scenario = AccountsScenario::<T>::new(origin_balance)?; 
-
-		// Original benchmark staking code (/frame/staking/src/benchmarking.rs)
-		let max_additional = BalanceOf::<T>::try_from(u128::MAX).map_err(|_| "balance expected to be a u128").unwrap() - origin_balance;
-
-		let stash = scenario.origin_stash1.clone();
-		let controller = scenario.origin_controller1.clone();
-		let original_bonded: BalanceOf<T>
-			= Ledger::<T>::get(&controller).map(|l| l.active).ok_or("ledger not created after")?;
-
-		T::Currency::deposit_into_existing(&stash, max_additional).unwrap();
-
-		whitelist_account!(stash);
-	}: _(RawOrigin::Signed(stash), max_additional)
-	verify {
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
-		let new_bonded: BalanceOf<T> = ledger.active;
-		assert!(original_bonded < new_bonded);
-	}
-
 	unbond {
 		// clean up any existing state.
 		clear_storages_and_edges::<T>();

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -143,13 +143,10 @@ pub mod pallet {
 	#[pallet::getter(fn bonded)]
 	pub type Bonded<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, T::AccountId>;
 
-	/// The minimum active bond to become and maintain the role of a storage network participant.
+	/// The bond size required to become and maintain the role of a CDN or storage network
+	/// participant.
 	#[pallet::storage]
-	pub type MinStorageBond<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
-
-	/// The minimum active bond to become and maintain the role of a CDN participant.
-	#[pallet::storage]
-	pub type MinEdgeBond<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+	pub type BondSize<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
 	/// Map from all (unlocked) "controller" accounts to the info regarding the staking.
 	#[pallet::storage]
@@ -206,9 +203,9 @@ pub mod pallet {
 		AlreadyBonded,
 		/// Controller is already paired.
 		AlreadyPaired,
-		/// Cannot have a storage network or CDN participant, with value less than the minimum
-		/// defined by governance (see `MinStorageBond` and `MinEdgeBond`). If unbonding is the
-		/// intention, `chill` first to remove one's role as storage/edge.
+		/// Cannot have a storage network or CDN participant, with the size less than defined by
+		/// governance (see `BondSize`). If unbonding is the intention, `chill` first to remove
+		/// one's role as storage/edge.
 		InsufficientBond,
 		/// Can not schedule more unlock chunks.
 		NoMoreChunks,
@@ -233,7 +230,6 @@ pub mod pallet {
 		pub fn bond(
 			origin: OriginFor<T>,
 			controller: <T::Lookup as StaticLookup>::Source,
-			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResult {
 			let stash = ensure_signed(origin)?;
 
@@ -247,29 +243,39 @@ pub mod pallet {
 				Err(Error::<T>::AlreadyPaired)?
 			}
 
+			let stash_free = T::Currency::free_balance(&stash);
+
 			// Reject a bond which is considered to be _dust_.
-			if value < T::Currency::minimum_balance() {
+			if stash_free < T::Currency::minimum_balance() {
+				Err(Error::<T>::InsufficientBond)?
+			}
+
+			let bond_size = BondSize::<T>::get();
+
+			// Reject a bond which is lower then required.
+			if stash_free < bond_size {
 				Err(Error::<T>::InsufficientBond)?
 			}
 
 			frame_system::Pallet::<T>::inc_consumers(&stash).map_err(|_| Error::<T>::BadState)?;
 
 			// You're auto-bonded forever, here. We might improve this by only bonding when
-			// you actually store/serve and remove once you unbond __everything__.
+			// you actually store/serve and remove once you unbond.
 			<Bonded<T>>::insert(&stash, &controller);
 
-			let stash_balance = T::Currency::free_balance(&stash);
-			let value = value.min(stash_balance);
-			Self::deposit_event(Event::<T>::Bonded(stash.clone(), value));
-			let item =
-				StakingLedger { stash, total: value, active: value, unlocking: Default::default() };
+			Self::deposit_event(Event::<T>::Bonded(stash.clone(), bond_size));
+			let item = StakingLedger {
+				stash,
+				total: bond_size,
+				active: bond_size,
+				unlocking: Default::default(),
+			};
 			Self::update_ledger(&controller, &item);
 			Ok(())
 		}
 
-		/// Schedule a portion of the stash to be unlocked ready for transfer out after the bond
-		/// period ends. If this leaves an amount actively bonded less than
-		/// T::Currency::minimum_balance(), then it is increased to the full amount.
+		/// Schedule a bond of the stash to be unlocked ready for transfer out after the bond
+		/// period ends.
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
 		///
@@ -278,7 +284,10 @@ pub mod pallet {
 		///
 		/// No more than a limited number of unlocking chunks (see `MaxUnlockingChunks`)
 		/// can co-exists at the same time. In that case, [`Call::withdraw_unbonded`] need
-		/// to be called first to remove some of the chunks (if possible).
+		/// to be called first to remove some of the chunks (if possible). This feature is actually
+		/// not required because we unlock the whole bond at once, means it is impossible to have
+		/// more then one unlocking at time. But this is inherited from the `pallet-staking` and we
+		/// may remove in some future version.
 		///
 		/// If a user encounters the `InsufficientBond` error when calling this extrinsic,
 		/// they should call `chill` first in order to free up their bonded funds.
@@ -293,54 +302,45 @@ pub mod pallet {
 		) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
+
+			if ledger.active.is_zero() {
+				// Nothing to unbond.
+				return Ok(())
+			}
+
 			ensure!(
 				ledger.unlocking.len() < MaxUnlockingChunks::get() as usize,
 				Error::<T>::NoMoreChunks,
 			);
 
-			let mut value = value.min(ledger.active);
+			// Make sure that the user maintains enough active bond for their role.
+			// If a user runs into this error, they should chill first.
+			ensure!(!Storages::<T>::contains_key(&ledger.stash), Error::<T>::InsufficientBond);
+			ensure!(!Edges::<T>::contains_key(&ledger.stash), Error::<T>::InsufficientBond);
 
-			if !value.is_zero() {
-				ledger.active -= value;
+			let era = Self::current_era().unwrap_or(0) + T::BondingDuration::get();
 
-				// Avoid there being a dust balance left in the staking system.
-				if ledger.active < T::Currency::minimum_balance() {
-					value += ledger.active;
-					ledger.active = Zero::zero();
-				}
+			// Unbond actual active stake instead of the current `BondSize` to allow users bond and
+			// unbond the same amount regardless of changes of the `BondSize`.
+			let unbond_value = ledger.active.clone();
+			ledger.active = Zero::zero();
 
-				let min_active_bond = if Storages::<T>::contains_key(&ledger.stash) {
-					MinStorageBond::<T>::get()
-				} else if Edges::<T>::contains_key(&ledger.stash) {
-					MinEdgeBond::<T>::get()
-				} else {
-					Zero::zero()
-				};
+			if let Some(mut chunk) = ledger.unlocking.last_mut().filter(|chunk| chunk.era == era) {
+				// To keep the chunk count down, we only keep one chunk per era. Since
+				// `unlocking` is a FiFo queue, if a chunk exists for `era` we know that it will
+				// be the last one.
+				chunk.value = chunk.value.defensive_saturating_add(unbond_value)
+			} else {
+				ledger
+					.unlocking
+					.try_push(UnlockChunk { value: unbond_value, era })
+					.map_err(|_| Error::<T>::NoMoreChunks)?;
+			};
+			// NOTE: ledger must be updated prior to calling `Self::weight_of`.
+			Self::update_ledger(&controller, &ledger);
 
-				// Make sure that the user maintains enough active bond for their role.
-				// If a user runs into this error, they should chill first.
-				ensure!(ledger.active >= min_active_bond, Error::<T>::InsufficientBond);
+			Self::deposit_event(Event::<T>::Unbonded(ledger.stash, unbond_value));
 
-				// Note: in case there is no current era it is fine to bond one era more.
-				let era = Self::current_era().unwrap_or(0) + T::BondingDuration::get();
-				if let Some(mut chunk) =
-					ledger.unlocking.last_mut().filter(|chunk| chunk.era == era)
-				{
-					// To keep the chunk count down, we only keep one chunk per era. Since
-					// `unlocking` is a FiFo queue, if a chunk exists for `era` we know that it will
-					// be the last one.
-					chunk.value = chunk.value.defensive_saturating_add(value)
-				} else {
-					ledger
-						.unlocking
-						.try_push(UnlockChunk { value, era })
-						.map_err(|_| Error::<T>::NoMoreChunks)?;
-				};
-				// NOTE: ledger must be updated prior to calling `Self::weight_of`.
-				Self::update_ledger(&controller, &ledger);
-
-				Self::deposit_event(Event::<T>::Unbonded(ledger.stash, value));
-			}
 			Ok(())
 		}
 
@@ -397,7 +397,7 @@ pub mod pallet {
 
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 
-			ensure!(ledger.active >= MinStorageBond::<T>::get(), Error::<T>::InsufficientBond);
+			ensure!(ledger.active >= BondSize::<T>::get(), Error::<T>::InsufficientBond);
 			let stash = &ledger.stash;
 
 			// Can't participate in storage network if already participating in CDN.
@@ -418,7 +418,7 @@ pub mod pallet {
 
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 
-			ensure!(ledger.active >= MinEdgeBond::<T>::get(), Error::<T>::InsufficientBond);
+			ensure!(ledger.active >= BondSize::<T>::get(), Error::<T>::InsufficientBond);
 			let stash = &ledger.stash;
 
 			// Can't participate in CDN if already participating in storage network.

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -298,7 +298,6 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::unbond())]
 		pub fn unbond(
 			origin: OriginFor<T>,
-			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;

--- a/pallets/ddc-staking/src/testing_utils.rs
+++ b/pallets/ddc-staking/src/testing_utils.rs
@@ -48,8 +48,7 @@ pub fn create_stash_controller<T: Config>(
 	let controller = create_funded_user::<T>("controller", n, balance_factor);
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
-	let amount = T::Currency::minimum_balance() * (balance_factor / 10).max(1).into();
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup, amount)?;
+	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	return Ok((stash, controller))
 }
 
@@ -63,7 +62,7 @@ pub fn create_stash_controller_with_balance<T: Config>(
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
 
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup, balance)?;
+	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	Ok((stash, controller))
 }
 
@@ -78,8 +77,7 @@ pub fn create_stash_and_dead_controller<T: Config>(
 	let controller = create_funded_user::<T>("controller", n, 0);
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
-	let amount = T::Currency::minimum_balance() * (balance_factor / 10).max(1).into();
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup, amount)?;
+	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	return Ok((stash, controller))
 }
 

--- a/pallets/ddc-staking/src/weights.rs
+++ b/pallets/ddc-staking/src/weights.rs
@@ -29,7 +29,6 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for pallet_staking.
 pub trait WeightInfo {
 	fn bond() -> Weight;
-	fn bond_extra() -> Weight;
 	fn unbond() -> Weight;
 	fn withdraw_unbonded() -> Weight;
 	fn store() -> Weight;
@@ -48,14 +47,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		(51_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-	}
-	// Storage: DdcStaking Bonded (r:1 w:0)
-	// Storage: DdcStaking Ledger (r:1 w:1)
-	// Storage: Balances Locks (r:1 w:1)
-	fn bond_extra() -> Weight {
-		(54_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: DdcStaking Ledger (r:1 w:0)
 	fn unbond() -> Weight {

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -126,7 +126,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 30700,
+	spec_version: 30701,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Updates

- `pallet-ddc-staking` now requires one fixed size bond for both `Storage` and `Edge` roles instead of the bond limited by the lower boundary only
- New `set_staking_configs` call in `pallet-ddc-staking` to allow to set DDC Staking bond size by the authority
- `spec_version` for the `cere-dev` runtime incremented
