### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*
+**target*
+doc
+Dockerfile*


### PR DESCRIPTION
Simplify local Docker image building by adding `.dockerignore`.

The content is a copy of [paritytech/substrate/.dockerignore](https://github.com/paritytech/substrate/blob/f4cb21c876d4ce19eb9ef09c39bebf83ba01d16d/.dockerignore) with generalization on ignorance of the dotfiles (for security and clarity), and docker files (for caching improvement).

Below is an example of the image content after `COPY`. 

```console
$ docker run -it sha256:ba04e1fa85f5e01160f8721d2fa5e61a0aa1dad8ea212cab19c86f854619d74f bash
root@f59d3fa08ab4:/cerenetwork# ls -lah
total 264K
drwxr-xr-x 1 root root  304 May 26 05:37 .
drwxr-xr-x 1 root root  190 May 26 05:38 ..
-rw-rw-r-- 1 root root  154 May 23 05:34 build.rs
-rw-rw-r-- 1 root root 222K May 26 05:25 Cargo.lock
-rw-rw-r-- 1 root root 1.1K May 23 05:34 Cargo.toml
-rw-rw-r-- 1 root root  804 May 26 05:33 CHANGELOG.md
drwxrwxr-x 1 root root   42 May 23 05:34 cli
-rw-rw-r-- 1 root root  236 May 23 05:34 docker-compose.yml
drwxrwxr-x 1 root root   26 May 23 05:34 docs
-rw-rw-r-- 1 root root 1.2K May 23 05:34 LICENSE
drwxrwxr-x 1 root root   26 May 23 05:34 node
drwxrwxr-x 1 root root  126 May 23 05:34 pallets
-rw-rw-r-- 1 root root 5.2K May 26 05:33 README.md
drwxrwxr-x 1 root root   26 May 23 05:34 rpc
drwxrwxr-x 1 root root   36 May 23 05:34 runtime
-rw-rw-r-- 1 root root  517 May 23 05:34 rustfmt.toml
-rw-rw-r-- 1 root root  109 May 26 05:33 rust-toolchain.toml
drwxrwxr-x 1 root root   14 May 23 05:34 scripts
-rw-rw-r-- 1 root root 1.2K May 23 05:34 shell.nix
drwxrwxr-x 1 root root   14 May 23 05:34 src
```