### PR TITLE
A set of updates for pallet-ddc-staking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.0]
 
-- ...
+### Added
+
+- DDC Staking `CurrentEra` follows DAC era counter
+
+### Changed
+
+- Preferences parameter removed from `pallet-ddc-staking` calls, `value` parameter returned back to `bond` and `unbond` calls
+- Distinct bond size requirements for `Storage` and `Edge` roles with default to 100 CERE
 
 ## [4.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ddc-staking"
-version = "0.1.0"
+version = "4.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ddc-staking"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/ddc-staking/Cargo.toml
+++ b/pallets/ddc-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ddc-staking"
-version = "0.1.0"
+version = "4.2.0"
 edition = "2021"
 
 [dependencies]

--- a/pallets/ddc-staking/Cargo.toml
+++ b/pallets/ddc-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ddc-staking"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 
 [dependencies]

--- a/pallets/ddc-staking/src/benchmarking.rs
+++ b/pallets/ddc-staking/src/benchmarking.rs
@@ -1,7 +1,7 @@
 //! DdcStaking pallet benchmarking.
 
 use super::*;
-use crate::Pallet as DddcStaking;
+use crate::Pallet as DdcStaking;
 use testing_utils::*;
 
 use frame_support::{ensure, traits::Currency};
@@ -31,7 +31,7 @@ pub fn clear_storages_with_edges<T: Config>(
 	for i in 0..n_storages {
 		let (stash, controller) = create_stash_controller::<T>(i + SEED, 100)?;
 		let storage_prefs = StoragePrefs { foo: true };
-		DddcStaking::<T>::store(RawOrigin::Signed(controller).into(), storage_prefs)?;
+		DdcStaking::<T>::store(RawOrigin::Signed(controller).into(), storage_prefs)?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		storages.push(stash_lookup);
 	}
@@ -41,7 +41,7 @@ pub fn clear_storages_with_edges<T: Config>(
 	for i in 0..n_edges {
 		let (stash, controller) = create_stash_controller::<T>(i + SEED, 100)?;
 		let edge_prefs = EdgePrefs { foo: true };
-		DddcStaking::<T>::serve(RawOrigin::Signed(controller).into(), edge_prefs)?;
+		DdcStaking::<T>::serve(RawOrigin::Signed(controller).into(), edge_prefs)?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		edges.push(stash_lookup);
 	}
@@ -113,7 +113,7 @@ benchmarks! {
 
 	withdraw_unbonded {
 		let (stash, controller) = create_stash_controller::<T>(0, 100)?;
-		DddcStaking::<T>::unbond(RawOrigin::Signed(controller.clone()).into())?;
+		DdcStaking::<T>::unbond(RawOrigin::Signed(controller.clone()).into())?;
 		CurrentEra::<T>::put(EraIndex::max_value());
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
 		let original_total: BalanceOf<T> = ledger.total;

--- a/pallets/ddc-staking/src/benchmarking.rs
+++ b/pallets/ddc-staking/src/benchmarking.rs
@@ -90,7 +90,7 @@ benchmarks! {
 		clear_storages_and_edges::<T>();
 
 		let total_issuance = T::Currency::total_issuance();
-		
+
 		// Constant taken from original benchmark staking code (/frame/staking/src/benchmarking.rs)
 		let origin_balance = BalanceOf::<T>::try_from(952_994_955_240_703u128)
 			.map_err(|_| "balance expected to be a u128")
@@ -114,7 +114,7 @@ benchmarks! {
 	withdraw_unbonded {
 		let (stash, controller) = create_stash_controller::<T>(0, 100)?;
 		DddcStaking::<T>::unbond(RawOrigin::Signed(controller.clone()).into())?;
-		CurrentEra::<T>::put(EraIndex::max_value()); 
+		CurrentEra::<T>::put(EraIndex::max_value());
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
 		let original_total: BalanceOf<T> = ledger.total;
 		whitelist_account!(controller);

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -308,9 +308,7 @@ pub mod pallet {
 		///
 		/// See also [`Call::withdraw_unbonded`].
 		#[pallet::weight(T::WeightInfo::unbond())]
-		pub fn unbond(
-			origin: OriginFor<T>,
-		) -> DispatchResult {
+		pub fn unbond(origin: OriginFor<T>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -15,7 +15,7 @@ use codec::{Decode, Encode, HasCompact};
 use frame_support::{
 	dispatch::Codec,
 	parameter_types,
-	traits::{Currency, DefensiveSaturating, LockIdentifier, WithdrawReasons},
+	traits::{Currency, DefensiveSaturating, LockIdentifier, UnixTime, WithdrawReasons},
 	BoundedVec,
 };
 use scale_info::TypeInfo;
@@ -136,6 +136,10 @@ pub mod pallet {
 		type BondingDuration: Get<EraIndex>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Time used for computing era index. It is guaranteed to start being called from the first
+		/// `on_finalize`.
+		type UnixTime: UnixTime;
 	}
 
 	/// Map from all locked "stash" accounts to the controller account.

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -398,7 +398,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
 		#[pallet::weight(T::WeightInfo::store())]
-		pub fn store(origin: OriginFor<T>, prefs: StoragePrefs) -> DispatchResult {
+		pub fn store(origin: OriginFor<T>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
@@ -409,7 +409,7 @@ pub mod pallet {
 			// Can't participate in storage network if already participating in CDN.
 			ensure!(!Edges::<T>::get().contains(&stash), Error::<T>::AlreadyInRole);
 
-			Self::do_add_storage(stash, prefs);
+			Self::do_add_storage(stash);
 			Ok(())
 		}
 
@@ -419,7 +419,7 @@ pub mod pallet {
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
 		#[pallet::weight(T::WeightInfo::serve())]
-		pub fn serve(origin: OriginFor<T>, prefs: EdgePrefs) -> DispatchResult {
+		pub fn serve(origin: OriginFor<T>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;
 
 			let ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
@@ -430,7 +430,7 @@ pub mod pallet {
 			// Can't participate in CDN if already participating in storage network.
 			ensure!(!Storages::<T>::get().contains(&stash), Error::<T>::AlreadyInRole);
 
-			Self::do_add_edge(stash, prefs);
+			Self::do_add_edge(stash);
 			Ok(())
 		}
 
@@ -556,7 +556,7 @@ pub mod pallet {
 		/// NOTE: you must ALWAYS use this function to add a storage network participant to the
 		/// system. Any access to `Storages` outside of this function is almost certainly
 		/// wrong.
-		pub fn do_add_storage(who: &T::AccountId, prefs: StoragePrefs) {
+		pub fn do_add_storage(who: &T::AccountId) {
 			Storages::<T>::append(who);
 		}
 
@@ -585,7 +585,7 @@ pub mod pallet {
 		/// NOTE: you must ALWAYS use this function to add a CDN participant to the system. Any
 		/// access to `Edges` outside of this function is almost certainly
 		/// wrong.
-		pub fn do_add_edge(who: &T::AccountId, prefs: EdgePrefs) {
+		pub fn do_add_edge(who: &T::AccountId) {
 			Edges::<T>::append(who);
 		}
 

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -102,18 +102,6 @@ impl<AccountId, Balance: HasCompact + Copy + Saturating + AtLeast32BitUnsigned +
 	}
 }
 
-/// Preference of what happens regarding to participating in storage network.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, Default)]
-pub struct StoragePrefs {
-	foo: bool, // ToDo
-}
-
-/// Preference of what happens regarding to participating in CDN.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, Default)]
-pub struct EdgePrefs {
-	foo: bool, // ToDo
-}
-
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -20,7 +20,7 @@ use frame_support::{
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, CheckedSub, Saturating, Zero},
+	traits::{AtLeast32BitUnsigned, Saturating, Zero},
 	RuntimeDebug,
 };
 

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -166,18 +166,15 @@ pub mod pallet {
 	pub type Ledger<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, StakingLedger<T::AccountId, BalanceOf<T>>>;
 
-	/// The map from (wannabe) storage network participant stash key to the preferences of that
-	/// storage network participant.
+	/// The list of (wannabe) storage network participants stash keys.
 	#[pallet::storage]
 	#[pallet::getter(fn storages)]
-	pub type Storages<T: Config> =
-		CountedStorageMap<_, Twox64Concat, T::AccountId, StoragePrefs, ValueQuery>;
+	pub type Storages<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
-	/// The map from (wannabe) CDN participant stash key to the preferences of that CDN participant.
+	/// The list of (wannabe) CDN participants stash keys.
 	#[pallet::storage]
 	#[pallet::getter(fn edges)]
-	pub type Edges<T: Config> =
-		CountedStorageMap<_, Twox64Concat, T::AccountId, EdgePrefs, ValueQuery>;
+	pub type Edges<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
 	/// The current era index.
 	///

--- a/pallets/ddc-staking/src/testing_utils.rs
+++ b/pallets/ddc-staking/src/testing_utils.rs
@@ -48,7 +48,8 @@ pub fn create_stash_controller<T: Config>(
 	let controller = create_funded_user::<T>("controller", n, balance_factor);
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
-	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
+	let amount = T::Currency::minimum_balance() * (balance_factor / 10).max(1).into();
+	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup, amount)?;
 	return Ok((stash, controller))
 }
 
@@ -62,74 +63,6 @@ pub fn create_stash_controller_with_balance<T: Config>(
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
 
-	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
+	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup, balance)?;
 	Ok((stash, controller))
-}
-
-/// Create a stash and controller pair, where the controller is dead, and payouts go to controller.
-/// This is used to test worst case payout scenarios.
-pub fn create_stash_and_dead_controller<T: Config>(
-	n: u32,
-	balance_factor: u32,
-) -> Result<(T::AccountId, T::AccountId), &'static str> {
-	let stash = create_funded_user::<T>("stash", n, balance_factor);
-	// controller has no funds
-	let controller = create_funded_user::<T>("controller", n, 0);
-	let controller_lookup: <T::Lookup as StaticLookup>::Source =
-		T::Lookup::unlookup(controller.clone());
-	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
-	return Ok((stash, controller))
-}
-
-/// create `max` validators.
-pub fn create_storages<T: Config>(
-	max: u32,
-	balance_factor: u32,
-) -> Result<Vec<<T::Lookup as StaticLookup>::Source>, &'static str> {
-	create_storages_with_seed::<T>(max, balance_factor, 0)
-}
-
-/// create `max` storages, with a seed to help unintentional prevent account collisions.
-pub fn create_storages_with_seed<T: Config>(
-	max: u32,
-	balance_factor: u32,
-	seed: u32,
-) -> Result<Vec<<T::Lookup as StaticLookup>::Source>, &'static str> {
-	let mut storages: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
-	for i in 0..max {
-		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		DdcStaking::<T>::store(RawOrigin::Signed(controller).into())?;
-		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
-		storages.push(stash_lookup);
-	}
-	Ok(storages)
-}
-
-/// create `max` validators.
-pub fn create_edges<T: Config>(
-	max: u32,
-	balance_factor: u32,
-) -> Result<Vec<<T::Lookup as StaticLookup>::Source>, &'static str> {
-	create_edges_with_seed::<T>(max, balance_factor, 0)
-}
-
-/// create `max` storages, with a seed to help unintentional prevent account collisions.
-pub fn create_edges_with_seed<T: Config>(
-	max: u32,
-	balance_factor: u32,
-	seed: u32,
-) -> Result<Vec<<T::Lookup as StaticLookup>::Source>, &'static str> {
-	let mut edges: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
-	for i in 0..max {
-		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		DdcStaking::<T>::serve(RawOrigin::Signed(controller).into())?;
-		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
-		edges.push(stash_lookup);
-	}
-	Ok(edges)
-}
-
-/// get the current era.
-pub fn current_era<T: Config>() -> EraIndex {
-	<Pallet<T>>::current_era().unwrap_or(0)
 }

--- a/pallets/ddc-staking/src/testing_utils.rs
+++ b/pallets/ddc-staking/src/testing_utils.rs
@@ -1,6 +1,6 @@
 //! Testing utils for ddc-staking.
 
-use crate::{Pallet as DddcStaking, *};
+use crate::{Pallet as DdcStaking, *};
 use frame_benchmarking::account;
 use frame_system::RawOrigin;
 
@@ -48,7 +48,7 @@ pub fn create_stash_controller<T: Config>(
 	let controller = create_funded_user::<T>("controller", n, balance_factor);
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
+	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	return Ok((stash, controller))
 }
 
@@ -62,7 +62,7 @@ pub fn create_stash_controller_with_balance<T: Config>(
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
 
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
+	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	Ok((stash, controller))
 }
 
@@ -77,7 +77,7 @@ pub fn create_stash_and_dead_controller<T: Config>(
 	let controller = create_funded_user::<T>("controller", n, 0);
 	let controller_lookup: <T::Lookup as StaticLookup>::Source =
 		T::Lookup::unlookup(controller.clone());
-	DddcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
+	DdcStaking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), controller_lookup)?;
 	return Ok((stash, controller))
 }
 
@@ -98,7 +98,7 @@ pub fn create_storages_with_seed<T: Config>(
 	let mut storages: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
 	for i in 0..max {
 		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		DddcStaking::<T>::store(RawOrigin::Signed(controller).into())?;
+		DdcStaking::<T>::store(RawOrigin::Signed(controller).into())?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		storages.push(stash_lookup);
 	}
@@ -122,7 +122,7 @@ pub fn create_edges_with_seed<T: Config>(
 	let mut edges: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
 	for i in 0..max {
 		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		DddcStaking::<T>::serve(RawOrigin::Signed(controller).into())?;
+		DdcStaking::<T>::serve(RawOrigin::Signed(controller).into())?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		edges.push(stash_lookup);
 	}

--- a/pallets/ddc-staking/src/testing_utils.rs
+++ b/pallets/ddc-staking/src/testing_utils.rs
@@ -12,8 +12,8 @@ const SEED: u32 = 0;
 
 /// This function removes all storage and edge nodes from storage.
 pub fn clear_storages_and_edges<T: Config>() {
-	Storages::<T>::remove_all();
-	Edges::<T>::remove_all();
+	Storages::<T>::kill();
+	Edges::<T>::kill();
 }
 
 /// Grab a funded user.
@@ -98,8 +98,7 @@ pub fn create_storages_with_seed<T: Config>(
 	let mut storages: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
 	for i in 0..max {
 		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		let storage_prefs = StoragePrefs { foo: true };
-		DddcStaking::<T>::store(RawOrigin::Signed(controller).into(), storage_prefs)?;
+		DddcStaking::<T>::store(RawOrigin::Signed(controller).into())?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		storages.push(stash_lookup);
 	}
@@ -123,8 +122,7 @@ pub fn create_edges_with_seed<T: Config>(
 	let mut edges: Vec<<T::Lookup as StaticLookup>::Source> = Vec::with_capacity(max as usize);
 	for i in 0..max {
 		let (stash, controller) = create_stash_controller::<T>(i + seed, balance_factor)?;
-		let edge_prefs = EdgePrefs { foo: true };
-		DddcStaking::<T>::serve(RawOrigin::Signed(controller).into(), edge_prefs)?;
+		DddcStaking::<T>::serve(RawOrigin::Signed(controller).into())?;
 		let stash_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(stash);
 		edges.push(stash_lookup);
 	}

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -92,7 +92,7 @@ pallet-transaction-storage = { version = "4.0.0-dev", default-features = false, 
 pallet-vesting = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 cere-runtime-common = { path = "../common", default-features = false }
 cere-dev-runtime-constants = { path = "./constants", default-features = false }
-pallet-ddc-staking = { version = "4.2.0", default-features = false, path = "../../pallets/ddc-staking" }
+pallet-ddc-staking = { version = "4.3.0", default-features = false, path = "../../pallets/ddc-staking" }
 pallet-chainbridge = { version = "4.3.0", default-features = false, path = "../../pallets/chainbridge" }
 pallet-cere-ddc = { version = "4.3.0", default-features = false, path = "../../pallets/ddc" }
 pallet-erc721 = { version = "4.3.0", default-features = false, path = "../../pallets/erc721" }

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -92,7 +92,7 @@ pallet-transaction-storage = { version = "4.0.0-dev", default-features = false, 
 pallet-vesting = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 cere-runtime-common = { path = "../common", default-features = false }
 cere-dev-runtime-constants = { path = "./constants", default-features = false }
-pallet-ddc-staking = { version = "0.1.0", default-features = false, path = "../../pallets/ddc-staking" }
+pallet-ddc-staking = { version = "4.2.0", default-features = false, path = "../../pallets/ddc-staking" }
 pallet-chainbridge = { version = "4.3.0", default-features = false, path = "../../pallets/chainbridge" }
 pallet-cere-ddc = { version = "4.3.0", default-features = false, path = "../../pallets/ddc" }
 pallet-erc721 = { version = "4.3.0", default-features = false, path = "../../pallets/erc721" }

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 43001,
+	spec_version: 43002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1262,6 +1262,7 @@ impl pallet_ddc_staking::Config for Runtime {
 	type BondingDuration = BondingDuration;
 	type Currency = Balances;
 	type Event = Event;
+	type UnixTime = Timestamp;
 	type WeightInfo = pallet_ddc_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1258,9 +1258,16 @@ impl pallet_ddc_metrics_offchain_worker::Config for Runtime {
 	type Call = Call;
 }
 
+parameter_types! {
+	pub const DefaultEdgeBondSize: Balance = 100 * DOLLARS;
+	pub const DefaultStorageBondSize: Balance = 100 * DOLLARS;
+}
+
 impl pallet_ddc_staking::Config for Runtime {
 	type BondingDuration = BondingDuration;
 	type Currency = Balances;
+	type DefaultEdgeBondSize = DefaultEdgeBondSize;
+	type DefaultStorageBondSize = DefaultStorageBondSize;
 	type Event = Event;
 	type UnixTime = Timestamp;
 	type WeightInfo = pallet_ddc_staking::weights::SubstrateWeight<Runtime>;

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -127,7 +127,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 43001,
+	spec_version: 43002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
* Remove `StoragePrefs` and `EdgePrefs` from blockchain storage items and extrinsics parameters,
* Store CDN and storage network participants list in the vector, instead of the map,
* Synchronize era counter with DAC,
* Distinct bond size requirements for `Storage` and `Edge` roles.