### PR TITLE
Set version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0]
+## [4.0.0]
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cere"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-cli",
  "sc-cli",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cere-cli"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-client",
  "cere-service",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cere-client"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-dev-runtime",
  "cere-runtime",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cere-dev-runtime"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-dev-runtime-constants",
  "cere-runtime-common",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "cere-dev-runtime-constants"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "node-primitives",
  "sp-runtime",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "cere-rpc"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "jsonrpsee",
  "node-primitives",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "cere-runtime"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-runtime-common",
  "cere-runtime-constants",
@@ -975,11 +975,11 @@ dependencies = [
 
 [[package]]
 name = "cere-runtime-common"
-version = "3.0.0-dev"
+version = "3.0.1"
 
 [[package]]
 name = "cere-runtime-constants"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "node-primitives",
  "sp-runtime",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "cere-service"
-version = "3.0.0-dev"
+version = "3.0.1"
 dependencies = [
  "cere-client",
  "cere-dev-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cere"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-cli",
  "sc-cli",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cere-cli"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-client",
  "cere-service",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cere-client"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-dev-runtime",
  "cere-runtime",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cere-dev-runtime"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-dev-runtime-constants",
  "cere-runtime-common",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "cere-dev-runtime-constants"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "node-primitives",
  "sp-runtime",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "cere-rpc"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "jsonrpsee",
  "node-primitives",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "cere-runtime"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-runtime-common",
  "cere-runtime-constants",
@@ -975,11 +975,11 @@ dependencies = [
 
 [[package]]
 name = "cere-runtime-common"
-version = "3.0.1"
+version = "4.0.0"
 
 [[package]]
 name = "cere-runtime-constants"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "node-primitives",
  "sp-runtime",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "cere-service"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "cere-client",
  "cere-dev-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 name = "cere"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 name = "cere"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
-version = "3.0.0-dev"
+version = "3.0.1"
 edition = "2021"
 build = "build.rs"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-cli"
-version = "3.0.0-dev"
+version = "3.0.1"
 edition = "2021"
 
 [package.metadata.wasm-pack.profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-cli"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 
 [package.metadata.wasm-pack.profile.release]

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -7,7 +7,7 @@ use sc_service::error::Error as ServiceError;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Substrate Node".into()
+		"Cere Node".into()
 	}
 
 	fn impl_version() -> String {

--- a/node/client/Cargo.toml
+++ b/node/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-client"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 
 [dependencies]

--- a/node/client/Cargo.toml
+++ b/node/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-client"
-version = "3.0.0-dev"
+version = "3.0.1"
 edition = "2021"
 
 [dependencies]

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-service"
-version = "3.0.0-dev"
+version = "3.0.1"
 edition = "2021"
 
 [dependencies]

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-service"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 
 [dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-rpc"
-version = "3.0.0-dev"
+version = "3.0.1"
 edition = "2021"
 
 [dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-rpc"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-dev-runtime"
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-dev-runtime"
-version = "3.0.0-dev"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/cere-dev/constants/Cargo.toml
+++ b/runtime/cere-dev/constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-dev-runtime-constants"
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/runtime/cere-dev/constants/Cargo.toml
+++ b/runtime/cere-dev/constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-dev-runtime-constants"
-version = "3.0.0-dev"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/runtime/cere/Cargo.toml
+++ b/runtime/cere/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime"
-version = "3.0.0-dev"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/cere/Cargo.toml
+++ b/runtime/cere/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime"
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/cere/constants/Cargo.toml
+++ b/runtime/cere/constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime-constants"
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/runtime/cere/constants/Cargo.toml
+++ b/runtime/cere/constants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime-constants"
-version = "3.0.0-dev"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime-common"
-version = "3.0.0-dev"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cere-runtime-common"
-version = "3.0.1"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
As in [Telemetry](https://telemetry.polkadot.io/#list/0x81443836a9a24caaa23f1241897d1235717535711d1d3fe24eae4fdc942c092c) we already can see v3.0.0 we've decided to start new node from v4.0.0 to avoid confusion in future.