### PR TITLE
Distinct staking settings for each cluster and deferred "chill"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [vNext]
 
+### Changed
+
+- DDC staking requirements now distinct for each DDC cluster
+- DDC participant stake chilling is delayed if the delay is not explicitly set to zero
+
 ## [4.5.0]
 
 ### Changed

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -486,11 +486,7 @@ pub mod pallet {
 				// Switching the cluster is prohibited. The user should chill first.
 				ensure!(current_cluster == cluster, Error::<T>::AlreadyInRole);
 				// Cancel previous "chill" attempts
-				Ledger::<T>::mutate(&controller, |maybe_ledger| {
-					if let Some(ref mut ledger) = maybe_ledger {
-						ledger.chilling = None
-					}
-				});
+				Self::reset_chilling(&controller);
 				return Ok(())
 			}
 
@@ -524,11 +520,7 @@ pub mod pallet {
 				// Switching the cluster is prohibited. The user should chill first.
 				ensure!(current_cluster == cluster, Error::<T>::AlreadyInRole);
 				// Cancel previous "chill" attempts
-				Ledger::<T>::mutate(&controller, |maybe_ledger| {
-					if let Some(ref mut ledger) = maybe_ledger {
-						ledger.chilling = None
-					}
-				});
+				Self::reset_chilling(&controller);
 				return Ok(())
 			}
 
@@ -596,11 +588,7 @@ pub mod pallet {
 
 			// It's time to chill.
 			Self::chill_stash(&ledger.stash);
-			Ledger::<T>::mutate(&controller, |maybe_ledger| {
-				if let Some(ref mut ledger) = maybe_ledger {
-					ledger.chilling = None // reset for future chilling
-				}
-			});
+			Self::reset_chilling(&controller); // for future chilling
 
 			Ok(())
 		}
@@ -760,6 +748,15 @@ pub mod pallet {
 		/// wrong.
 		pub fn do_remove_storage(who: &T::AccountId) -> bool {
 			Storages::<T>::take(who).is_some()
+		}
+
+		/// Reset the chilling era for a controller.
+		pub fn reset_chilling(controller: &T::AccountId) {
+			Ledger::<T>::mutate(&controller, |maybe_ledger| {
+				if let Some(ref mut ledger) = maybe_ledger {
+					ledger.chilling = None
+				}
+			});
 		}
 	}
 }

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -120,9 +120,13 @@ pub struct ClusterSettings<T: Config> {
 	/// The bond size required to become and maintain the role of a CDN participant.
 	#[codec(compact)]
 	pub edge_bond_size: BalanceOf<T>,
+	/// Number of eras should pass before a CDN participant can chill.
+	pub edge_chill_delay: EraIndex,
 	/// The bond size required to become and maintain the role of a storage network participant.
 	#[codec(compact)]
 	pub storage_bond_size: BalanceOf<T>,
+	/// Number of eras should pass before a storage network participant can chill.
+	pub storage_chill_delay: EraIndex,
 }
 
 impl<T: pallet::Config> Default for ClusterSettings<T> {
@@ -130,7 +134,9 @@ impl<T: pallet::Config> Default for ClusterSettings<T> {
 	fn default() -> Self {
 		Self {
 			edge_bond_size: T::DefaultEdgeBondSize::get(),
+			edge_chill_delay: T::DefaultEdgeChillDelay::get(),
 			storage_bond_size: T::DefaultStorageBondSize::get(),
+			storage_chill_delay: T::DefaultStorageChillDelay::get(),
 		}
 	}
 }

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -269,6 +269,8 @@ pub mod pallet {
 		/// An account already declared a desire to participate in the network with a certain role
 		/// and to take another role it should call `chill` first.
 		AlreadyInRole,
+		/// Action is allowed at some point of time in future not reached yet.
+		TooEarly,
 	}
 
 	#[pallet::hooks]

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -114,7 +114,7 @@ impl<AccountId, Balance: HasCompact + Copy + Saturating + AtLeast32BitUnsigned +
 }
 
 /// Cluster staking parameters.
-#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebugNoBound, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 pub struct ClusterSettings<T: Config> {
 	/// The bond size required to become and maintain the role of a CDN participant.

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -183,6 +183,12 @@ pub mod pallet {
 	#[pallet::getter(fn bonded)]
 	pub type Bonded<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, T::AccountId>;
 
+	/// DDC clusters staking settings.
+	#[pallet::storage]
+	#[pallet::getter(fn settings)]
+	pub type Settings<T: Config> =
+		StorageMap<_, Identity, ClusterId, ClusterSettings<T>, ValueQuery>;
+
 	/// The bond size required to become and maintain the role of a CDN participant.
 	#[pallet::storage]
 	pub type EdgeBondSize<T: Config> =

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -481,6 +481,13 @@ pub mod pallet {
 			// Can't participate in CDN if already participating in storage network.
 			ensure!(!Storages::<T>::contains_key(&stash), Error::<T>::AlreadyInRole);
 
+			// Cancel previous "chill" attempts
+			Ledger::<T>::mutate(&controller, |maybe_ledger| {
+				if let Some(ref mut ledger) = maybe_ledger {
+					ledger.chilling = None
+				}
+			});
+
 			Self::do_add_edge(stash, cluster);
 			Ok(())
 		}
@@ -506,7 +513,15 @@ pub mod pallet {
 			// Can't participate in storage network if already participating in CDN.
 			ensure!(!Edges::<T>::contains_key(&stash), Error::<T>::AlreadyInRole);
 
+			// Cancel previous "chill" attempts
+			Ledger::<T>::mutate(&controller, |maybe_ledger| {
+				if let Some(ref mut ledger) = maybe_ledger {
+					ledger.chilling = None
+				}
+			});
+
 			Self::do_add_storage(stash, cluster);
+
 			Ok(())
 		}
 

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -600,6 +600,21 @@ pub mod pallet {
 			}
 		}
 
+		/// Note a desire of a stash account to chill soon.
+		fn chill_stash_soon(
+			stash: &T::AccountId,
+			controller: &T::AccountId,
+			cluster: ClusterId,
+			can_chill_from: EraIndex,
+		) {
+			Ledger::<T>::mutate(&controller, |maybe_ledger| {
+				if let Some(ref mut ledger) = maybe_ledger {
+					ledger.chilling = Some(can_chill_from)
+				}
+			});
+			Self::deposit_event(Event::<T>::ChillSoon(stash.clone(), cluster, can_chill_from));
+		}
+
 		/// Remove all associated data of a stash account from the staking system.
 		///
 		/// Assumes storage is upgraded before calling.

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -533,6 +533,12 @@ pub mod pallet {
 				return Ok(()) // already chilled
 			};
 
+			if delay == 0 {
+				// No delay is set, so we can chill right away.
+				Self::chill_stash(&ledger.stash);
+				return Ok(())
+			}
+
 			let can_chill_from = current_era.defensive_saturating_add(delay);
 			match ledger.chilling {
 				None => {

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -460,7 +460,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Declare the desire to participate in CDN for the origin controller.
+		/// Declare the desire to participate in CDN for the origin controller. Also works to cancel
+		/// a previous "chill".
 		///
 		/// `cluster` is the ID of the DDC cluster the participant wishes to join.
 		///
@@ -497,7 +498,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Declare the desire to participate in storage network for the origin controller.
+		/// Declare the desire to participate in storage network for the origin controller. Also
+		/// works to cancel a previous "chill".
 		///
 		/// `cluster` is the ID of the DDC cluster the participant wishes to join.
 		///

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -512,9 +512,20 @@ pub mod pallet {
 
 		/// Declare no desire to either participate in storage network or CDN.
 		///
-		/// Effects will be felt at the beginning of the next era.
+		/// Only in case the delay for the role _origin_ maintains in the cluster is set to zero in
+		/// cluster settings, it removes the participant immediately. Otherwise, it requires at
+		/// least two invocations to effectively remove the participant. The first invocation only
+		/// updates the [`Ledger`] to note the DDC era at which the participant may "chill" (current
+		/// era + the delay from the cluster settings). The second invocation made at the noted era
+		/// (or any further era) will remove the participant from the list of CDN or storage network
+		/// participants. If the cluster settings updated significantly decreasing the delay, one
+		/// may invoke it again to decrease the era at with the participant may "chill". But it
+		/// never increases the era at which the participant may "chill" even when the cluster
+		/// settings updated increasing the delay.
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		///
+		/// Emits `ChillSoon`, `Chill`.
 		#[pallet::weight(T::WeightInfo::chill())]
 		pub fn chill(origin: OriginFor<T>) -> DispatchResult {
 			let controller = ensure_signed(origin)?;

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -112,6 +112,28 @@ impl<AccountId, Balance: HasCompact + Copy + Saturating + AtLeast32BitUnsigned +
 	}
 }
 
+/// Cluster staking parameters.
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct ClusterSettings<T: Config> {
+	/// The bond size required to become and maintain the role of a CDN participant.
+	#[codec(compact)]
+	pub edge_bond_size: BalanceOf<T>,
+	/// The bond size required to become and maintain the role of a storage network participant.
+	#[codec(compact)]
+	pub storage_bond_size: BalanceOf<T>,
+}
+
+impl<T: pallet::Config> Default for ClusterSettings<T> {
+	/// Default to the values specified in the runtime config.
+	fn default() -> Self {
+		Self {
+			edge_bond_size: T::DefaultEdgeBondSize::get(),
+			storage_bond_size: T::DefaultStorageBondSize::get(),
+		}
+	}
+}
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -11,19 +11,19 @@ pub mod weights;
 use crate::weights::WeightInfo;
 
 use codec::{Decode, Encode, HasCompact};
-
+use frame_system::pallet_prelude::*;
 use frame_support::{
-	dispatch::Codec,
-	parameter_types,
-	traits::{Currency, DefensiveSaturating, LockIdentifier, UnixTime, WithdrawReasons},
 	BoundedVec,
+	dispatch::Codec,
+	pallet_prelude::*,
+	parameter_types,
+	traits::{Currency, DefensiveSaturating, LockableCurrency, LockIdentifier, UnixTime, WithdrawReasons},
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Saturating, Zero},
+	traits::{AtLeast32BitUnsigned, Saturating, Zero, StaticLookup},
 	RuntimeDebug,
 };
-
 use sp_staking::EraIndex;
 use sp_std::prelude::*;
 
@@ -115,11 +115,6 @@ impl<AccountId, Balance: HasCompact + Copy + Saturating + AtLeast32BitUnsigned +
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{
-		pallet_prelude::*, sp_runtime::traits::StaticLookup, traits::LockableCurrency,
-		Blake2_128Concat,
-	};
-	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -11,17 +11,18 @@ pub mod weights;
 use crate::weights::WeightInfo;
 
 use codec::{Decode, Encode, HasCompact};
-use frame_system::pallet_prelude::*;
 use frame_support::{
-	BoundedVec,
-	dispatch::Codec,
 	pallet_prelude::*,
 	parameter_types,
-	traits::{Currency, DefensiveSaturating, LockableCurrency, LockIdentifier, UnixTime, WithdrawReasons},
+	traits::{
+		Currency, DefensiveSaturating, LockIdentifier, LockableCurrency, UnixTime, WithdrawReasons,
+	},
+	BoundedVec,
 };
+use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, Saturating, Zero, StaticLookup},
+	traits::{AtLeast32BitUnsigned, Saturating, StaticLookup, Zero},
 	RuntimeDebug,
 };
 use sp_staking::EraIndex;

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -152,9 +152,17 @@ pub mod pallet {
 		#[pallet::constant]
 		type DefaultEdgeBondSize: Get<BalanceOf<Self>>;
 
+		/// Default number or DDC eras required to pass before a CDN participant can chill.
+		#[pallet::constant]
+		type DefaultEdgeChillDelay: Get<EraIndex>;
+
 		/// Default bond size for a storage network participant.
 		#[pallet::constant]
 		type DefaultStorageBondSize: Get<BalanceOf<Self>>;
+
+		/// Default number or DDC eras required to pass before a storage participant can chill.
+		#[pallet::constant]
+		type DefaultStorageChillDelay: Get<EraIndex>;
 
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Number of eras that staked funds must remain bonded for.

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -241,8 +241,8 @@ pub mod pallet {
 		NoMoreChunks,
 		/// Internal state has become somehow corrupted and the operation cannot continue.
 		BadState,
-		// An account already declared a desire to participate in the network with a certain role
-		// and to take another role it should call `chill` first.
+		/// An account already declared a desire to participate in the network with a certain role
+		/// and to take another role it should call `chill` first.
 		AlreadyInRole,
 	}
 

--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -243,6 +243,9 @@ pub mod pallet {
 		/// An account has stopped participating as either a storage network or CDN participant.
 		/// \[stash\]
 		Chilled(T::AccountId),
+		/// An account has declared desire to stop participating in CDN or storage network soon.
+		/// \[stash, cluster, era\]
+		ChillSoon(T::AccountId, ClusterId, EraIndex),
 	}
 
 	#[pallet::error]

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -129,7 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 45000,
+	spec_version: 45001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -76,6 +76,7 @@ use sp_runtime::{
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, FixedPointNumber, Perbill, Percent, Permill, Perquintill,
 };
+use sp_staking::EraIndex;
 use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
@@ -1260,14 +1261,18 @@ impl pallet_ddc_metrics_offchain_worker::Config for Runtime {
 
 parameter_types! {
 	pub const DefaultEdgeBondSize: Balance = 100 * DOLLARS;
+	pub const DefaultEdgeChillDelay: EraIndex = 7 * 24 * 60 / 2; // approx. 1 week with 2 min DDC era
 	pub const DefaultStorageBondSize: Balance = 100 * DOLLARS;
+	pub const DefaultStorageChillDelay: EraIndex = 7 * 24 * 60 / 2; // approx. 1 week with 2 min DDC era
 }
 
 impl pallet_ddc_staking::Config for Runtime {
 	type BondingDuration = BondingDuration;
 	type Currency = Balances;
 	type DefaultEdgeBondSize = DefaultEdgeBondSize;
+	type DefaultEdgeChillDelay = DefaultEdgeChillDelay;
 	type DefaultStorageBondSize = DefaultStorageBondSize;
+	type DefaultStorageChillDelay = DefaultStorageChillDelay;
 	type Event = Event;
 	type UnixTime = Timestamp;
 	type WeightInfo = pallet_ddc_staking::weights::SubstrateWeight<Runtime>;

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -127,7 +127,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 45000,
+	spec_version: 45001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,


### PR DESCRIPTION
- DDC staking requirements now distinct for each DDC cluster
- DDC participant stake chilling is delayed if the delay is not explicitly set to zero

Migrations are missed because only the dev runtime is updated.