### PR TITLE
Add Deterministic WebAssembly Runtime Build for Cere and Cere-Dev in GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,3 +75,10 @@ jobs:
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json
           cat ${{ matrix.chain }}-srtool-digest.json
           echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+      - name: Archive Runtime
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.chain }}-runtime-${{ github.sha }}
+          path: |
+            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ matrix.chain }}-srtool-digest.json


### PR DESCRIPTION
The primary goal of this task is to implement a deterministic build process for the WebAssembly runtime of both `cere` and `cere-dev`, using GitHub's Continuous Integration (CI) pipeline. 
By deterministic build, we mean that multiple builds of the same source code will produce an identical output. Additionally, we aim to generate build artifacts during the CI pipeline execution for ease of access and reference.