### PR TITLE
Fix contracts dissapearing

### DIFF
--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1444,6 +1444,7 @@ pub type Executive = frame_executive::Executive<
 			StakingMigrationV11OldPallet,
 		>,
 		pallet_staking::migrations::v12::MigrateToV12<Runtime>,
+		pallet_contracts::Migration<Runtime>,
 	),
 >;
 

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1423,6 +1423,7 @@ pub type Executive = frame_executive::Executive<
 			StakingMigrationV11OldPallet,
 		>,
 		pallet_staking::migrations::v12::MigrateToV12<Runtime>,
+		pallet_contracts::Migration<Runtime>,
 	),
 >;
 


### PR DESCRIPTION
[This missed migration](https://github.com/paritytech/substrate/pull/12083/files) caused smart contracts disappearance. We missed it as we rely on the migration of Polkadot source code but Polkadot doesn't have smart contracts in its dependencies. In the future, we need to check Substrate source code too.