### PR TITLE
Use default toolchain for cargo fmt

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check Format
         run: |
-          cargo +nightly fmt -- --check
+          cargo fmt -- --check
 
       - name: Check Build
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,5 @@
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true
-    },
-    "rust-analyzer.rustfmt.extraArgs": [
-        "+nightly"
-    ]
+    }
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Prevent committing badly formatted code
-cargo +nightly fmt -- --check
+cargo fmt -- --check
 if [ $? -ne 0 ]; then
-	echo "Run \`cargo +nightly fmt\` to fix formatting issues before committing."
+	echo "Run \`cargo fmt\` to fix formatting issues before committing."
 	exit 1
 fi


### PR DESCRIPTION
We no longer need to pass toolchain to cargo fmt invocations because it is specified in `rust-toolchain.toml`. At the same time, preserving the toolchain argument may become an issue if the latest `nightly` defaults are changed and become not the same as defaults for the toolchain specified in `rust-toolchain.toml`.