### PR TITLE
Fix runtime loading from file for cere-dev chains

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -43,11 +43,14 @@ impl SubstrateCli for Cli {
 			"local" => Box::new(cere_service::chain_spec::cere_dev_local_testnet_config()?),
 			path => {
 				let path = std::path::PathBuf::from(path);
+				let chain_spec =
+					Box::new(cere_service::CereChainSpec::from_json_file(path.clone())?)
+						as Box<dyn cere_service::ChainSpec>;
 
-				if self.run.force_cere_dev {
+				if self.run.force_cere_dev || chain_spec.is_cere_dev() {
 					Box::new(cere_service::CereDevChainSpec::from_json_file(path)?)
 				} else {
-					Box::new(cere_service::CereChainSpec::from_json_file(path)?)
+					chain_spec
 				}
 			},
 		})


### PR DESCRIPTION
Chain specifications with IDs prefixed by `cere_dev` are [considered](https://github.com/search?q=repo%3ACerebellum-Network%2Fblockchain-node%20is_cere_dev&type=code) to use `cere-dev` runtime which we can currently force by `--force-cere-dev`. But in a `build-spec` subcommand the key is not implemented. Polkadot [checks](https://github.com/paritytech/polkadot-sdk/blob/50de035f6d33b7233fd263892dd263d52b997f5c/polkadot/cli/src/command.rs#L148) for a prefix in the specification loader which we may want to implement as well. It will fix the `build-spec` behavior for chains that require `cere-dev` runtime for specifications loaded from a file.