### PR TITLE
Cluster node authorization by extension contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "pallet-contracts",
  "pallet-ddc-nodes",
  "parity-scale-codec",
  "scale-info",

--- a/pallets/ddc-clusters/Cargo.toml
+++ b/pallets/ddc-clusters/Cargo.toml
@@ -15,6 +15,7 @@ sp-runtime = { version = "6.0.0", default-features = false, git = "https://githu
 sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", default-features = false }
+pallet-contracts = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 pallet-ddc-nodes = { version = "4.7.0", default-features = false, path = "../ddc-nodes" }
 
 [dev-dependencies]
@@ -29,6 +30,7 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "frame-benchmarking/std",
+  "pallet-contracts/std",
   "scale-info/std",
   "sp-io/std",
   "sp-runtime/std",

--- a/pallets/ddc-clusters/src/cluster.rs
+++ b/pallets/ddc-clusters/src/cluster.rs
@@ -15,6 +15,7 @@ pub struct Cluster<AccountId> {
 	pub cluster_id: ClusterId,
 	pub manager_id: AccountId,
 	pub props: ClusterProps<AccountId>,
+	pub extension_smart_contract: AccountId,
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
@@ -37,6 +38,7 @@ impl<AccountId> Cluster<AccountId> {
 		cluster_id: ClusterId,
 		manager_id: AccountId,
 		cluster_params: ClusterParams<AccountId>,
+		extension_smart_contract: AccountId,
 	) -> Result<Cluster<AccountId>, ClusterError> {
 		Ok(Cluster {
 			cluster_id,
@@ -48,6 +50,7 @@ impl<AccountId> Cluster<AccountId> {
 				},
 				node_provider_auth_contract: cluster_params.node_provider_auth_contract,
 			},
+			extension_smart_contract,
 		})
 	}
 

--- a/pallets/ddc-clusters/src/cluster.rs
+++ b/pallets/ddc-clusters/src/cluster.rs
@@ -15,7 +15,6 @@ pub struct Cluster<AccountId> {
 	pub cluster_id: ClusterId,
 	pub manager_id: AccountId,
 	pub props: ClusterProps<AccountId>,
-	pub extension_smart_contract: AccountId,
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
@@ -38,7 +37,6 @@ impl<AccountId> Cluster<AccountId> {
 		cluster_id: ClusterId,
 		manager_id: AccountId,
 		cluster_params: ClusterParams<AccountId>,
-		extension_smart_contract: AccountId,
 	) -> Result<Cluster<AccountId>, ClusterError> {
 		Ok(Cluster {
 			cluster_id,
@@ -50,7 +48,6 @@ impl<AccountId> Cluster<AccountId> {
 				},
 				node_provider_auth_contract: cluster_params.node_provider_auth_contract,
 			},
-			extension_smart_contract,
 		})
 	}
 

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -13,6 +13,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
+#![feature(is_some_and)] // ToDo: delete at rustc > 1.70
 
 use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::*;

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -29,6 +29,10 @@ pub use crate::cluster::{Cluster, ClusterError, ClusterId, ClusterParams};
 /// https://use.ink/macros-attributes/selector/.
 const INK_SELECTOR_IS_AUTHORIZED: [u8; 4] = [0x96, 0xb0, 0x45, 0x3e];
 
+/// The maximum amount of weight that the cluster extension contract call is allowed to consume.
+/// See also https://github.com/paritytech/substrate/blob/a3ed0119c45cdd0d571ad34e5b3ee7518c8cef8d/frame/contracts/rpc/src/lib.rs#L63.
+const EXTENSION_CALL_GAS_LIMIT: Weight = Weight::from_ref_time(5_000_000_000_000);
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -122,7 +126,7 @@ pub mod pallet {
 				caller_id,
 				cluster.props.node_provider_auth_contract,
 				Default::default(),
-				Default::default(),
+				EXTENSION_CALL_GAS_LIMIT,
 				None,
 				Vec::from(INK_SELECTOR_IS_AUTHORIZED),
 				false,

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::cluster::{Cluster, ClusterError, ClusterId, ClusterParams};
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use pallet_contracts::chain_extension::UncheckedFrom;
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -32,7 +33,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + pallet_contracts::Config {
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		type NodeRepository: NodeRepository<Self>;
 	}
@@ -76,7 +77,10 @@ pub mod pallet {
 	>;
 
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>,
+	{
 		#[pallet::weight(10_000)]
 		pub fn create_cluster(
 			origin: OriginFor<T>,

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -24,6 +24,11 @@ mod cluster;
 
 pub use crate::cluster::{Cluster, ClusterError, ClusterId, ClusterParams};
 
+/// ink! 4.x selector for the "is_authorized" message, equals to the first four bytes of the
+/// blake2("is_authorized"). See also: https://use.ink/basics/selectors#selector-calculation/,
+/// https://use.ink/macros-attributes/selector/.
+const INK_SELECTOR_IS_AUTHORIZED: [u8; 4] = [0x96, 0xb0, 0x45, 0x3e];
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -119,7 +124,7 @@ pub mod pallet {
 				Default::default(),
 				Default::default(),
 				None,
-				Vec::from([0x96, 0xb0, 0x45, 0x3e]), // blake2("is_authorized"), https://use.ink/basics/selectors#selector-calculation
+				Vec::from(INK_SELECTOR_IS_AUTHORIZED),
 				false,
 			)
 			.result?

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -89,16 +89,10 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			cluster_id: ClusterId,
 			cluster_params: ClusterParams<T::AccountId>,
-			extension_smart_contract: T::AccountId,
 		) -> DispatchResult {
 			let caller_id = ensure_signed(origin)?;
-			let cluster = Cluster::new(
-				cluster_id.clone(),
-				caller_id,
-				cluster_params,
-				extension_smart_contract,
-			)
-			.map_err(|e: ClusterError| Into::<Error<T>>::into(ClusterError::from(e)))?;
+			let cluster = Cluster::new(cluster_id.clone(), caller_id, cluster_params)
+				.map_err(|e: ClusterError| Into::<Error<T>>::into(ClusterError::from(e)))?;
 			ensure!(!Clusters::<T>::contains_key(&cluster_id), Error::<T>::ClusterAlreadyExists);
 			Clusters::<T>::insert(cluster_id.clone(), cluster);
 			Self::deposit_event(Event::<T>::ClusterCreated { cluster_id });
@@ -121,7 +115,7 @@ pub mod pallet {
 
 			let is_authorized: bool = pallet_contracts::Pallet::<T>::bare_call(
 				caller_id,
-				cluster.extension_smart_contract,
+				cluster.props.node_provider_auth_contract,
 				Default::default(),
 				Default::default(),
 				None,

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -19,6 +19,7 @@ use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use pallet_ddc_nodes::{NodePubKey, NodeRepository, NodeTrait};
+use sp_std::prelude::*;
 mod cluster;
 
 pub use crate::cluster::{Cluster, ClusterError, ClusterId, ClusterParams};

--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -82,10 +82,16 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			cluster_id: ClusterId,
 			cluster_params: ClusterParams<T::AccountId>,
+			extension_smart_contract: T::AccountId,
 		) -> DispatchResult {
 			let caller_id = ensure_signed(origin)?;
-			let cluster = Cluster::new(cluster_id.clone(), caller_id, cluster_params)
-				.map_err(|e: ClusterError| Into::<Error<T>>::into(ClusterError::from(e)))?;
+			let cluster = Cluster::new(
+				cluster_id.clone(),
+				caller_id,
+				cluster_params,
+				extension_smart_contract,
+			)
+			.map_err(|e: ClusterError| Into::<Error<T>>::into(ClusterError::from(e)))?;
 			ensure!(!Clusters::<T>::contains_key(&cluster_id), Error::<T>::ClusterAlreadyExists);
 			Clusters::<T>::insert(cluster_id.clone(), cluster);
 			Self::deposit_event(Event::<T>::ClusterCreated { cluster_id });


### PR DESCRIPTION
Allow setting a DDC cluster extension contract address during the creation of a cluster. And test a new node for authorization by the extension contract before adding it to the cluster. Not tested.