### PR TITLE
Allow chill in the next era for nodes not attending any cluster

### DIFF
--- a/pallets/ddc-staking/src/lib.rs
+++ b/pallets/ddc-staking/src/lib.rs
@@ -1030,7 +1030,7 @@ pub mod pallet {
 		}
 
 		/// Note a desire of a stash account to chill soon.
-		fn chill_stash_soon(
+		pub fn chill_stash_soon(
 			stash: &T::AccountId,
 			controller: &T::AccountId,
 			cluster: ClusterId,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 48009,
+	spec_version: 48010,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,


### PR DESCRIPTION
New `fast_chill` extrinsic call hander which allows cluster node candidates to revoke their DDC Staking stake quickly in case they are not attending in any cluster.

Also an additional check in the `add_node` to ensure the candidate is not planning to chill when we consider adding it to the cluster.

Manually tested locally.