### PR TITLE
Pass provider and node ids to the auth extension

### DIFF
--- a/pallets/ddc-clusters/src/lib.rs
+++ b/pallets/ddc-clusters/src/lib.rs
@@ -156,13 +156,19 @@ pub mod pallet {
 			ensure!(!chilling, Error::<T>::ChillingProhibited);
 
 			// Cluster extension smart contract allows joining.
+			// is_authorized(node_provider: AccountId, node: Vec<u8>, node_variant: u8) -> bool
+			let mut call_data = Vec::new();
+			call_data.extend_from_slice(&INK_SELECTOR_IS_AUTHORIZED);
+			call_data.append(&mut node_provider_stash.encode());
+			call_data.append(&mut node_pub_key.encode());
+			call_data.push(node_pub_key.variant_as_number());
 			let is_authorized: bool = pallet_contracts::Pallet::<T>::bare_call(
 				caller_id,
 				cluster.props.node_provider_auth_contract,
 				Default::default(),
 				EXTENSION_CALL_GAS_LIMIT,
 				None,
-				Vec::from(INK_SELECTOR_IS_AUTHORIZED),
+				call_data,
 				false,
 			)
 			.result?

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -17,5 +17,14 @@ pub enum NodePubKey {
 	CDNPubKey(CDNNodePubKey),
 }
 
+impl NodePubKey {
+	pub fn variant_as_number(&self) -> u8 {
+		match self {
+			NodePubKey::CDNPubKey(_) => 0,
+			NodePubKey::StoragePubKey(_) => 1,
+		}
+	}
+}
+
 pub type StorageNodePubKey = AccountId32;
 pub type CDNNodePubKey = AccountId32;

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 48010,
+	spec_version: 48011,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,


### PR DESCRIPTION
* Cluster authorization extension contract message definition updated to `is_authorized(node_provider: AccountId, node: Vec<u8>, node_variant: u8) -> bool`. Future implementations may define `ddc_primitives::NodePubKey` for the `ink!` side to use it instead of the byte array.
* Custom `NodePubKey::variant_as_number()` function created instead of the `From` implementation in order to not confuse the user with the conversion provided by the specific type of the key variant.

Manually tested locally.