### PR TITLE
'StorageHasher' type for the Ledger map is changed to a more secure one

### DIFF
--- a/pallets/ddc-customers/src/lib.rs
+++ b/pallets/ddc-customers/src/lib.rs
@@ -177,8 +177,12 @@ pub mod pallet {
 	/// Map from all (unlocked) "owner" accounts to the info regarding the staking.
 	#[pallet::storage]
 	#[pallet::getter(fn ledger)]
-	pub type Ledger<T: Config> =
-		StorageMap<_, Identity, T::AccountId, AccountsLedger<T::AccountId, BalanceOf<T>, T>>;
+	pub type Ledger<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		AccountsLedger<T::AccountId, BalanceOf<T>, T>,
+	>;
 
 	#[pallet::type_value]
 	pub fn DefaultBucketCount<T: Config>() -> BucketId {


### PR DESCRIPTION
Based on a discussion with @Raid5594 and @khssnv we concluded that it is better to use a cryptographically safe hasher here as in theory a malicious user can generate a number of accounts with the same prefix by brute-forcing and this way create an unbalanced tree.

No migration is needed at the moment as neither Devnet nor Testnet has any active Ledgers.