### PR TITLE
Genesis config for `pallet-ddc-clusters`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4730,6 +4730,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -235,6 +235,7 @@ pub fn cere_dev_genesis(
 		transaction_payment: Default::default(),
 		ddc_customers: Default::default(),
 		nomination_pools: Default::default(),
+		ddc_clusters: Default::default(),
 	}
 }
 

--- a/pallets/ddc-clusters/Cargo.toml
+++ b/pallets/ddc-clusters/Cargo.toml
@@ -13,6 +13,7 @@ hex-literal = "^0.3.1"
 pallet-contracts = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.31" }
 pallet-ddc-nodes = { version = "4.7.0", default-features = false, path = "../ddc-nodes" }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+serde = { version = "1.0.136", default-features = false, features = ["derive"], optional = true }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.31" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.31" }
 
@@ -29,6 +30,7 @@ substrate-test-utils = { git = "https://github.com/paritytech/substrate.git", br
 default = ["std"]
 std = [
   "codec/std",
+  "serde",
   "ddc-primitives/std",
   "frame-support/std",
   "frame-system/std",

--- a/pallets/ddc-clusters/src/cluster.rs
+++ b/pallets/ddc-clusters/src/cluster.rs
@@ -3,11 +3,14 @@ use codec::{Decode, Encode};
 use ddc_primitives::{ClusterId, ClusterParams};
 use frame_support::{pallet_prelude::*, parameter_types};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
 
 parameter_types! {
 	pub MaxClusterParamsLen: u16 = 2048;
 }
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
 pub struct Cluster<AccountId> {
 	pub cluster_id: ClusterId,
@@ -16,6 +19,7 @@ pub struct Cluster<AccountId> {
 	pub props: ClusterProps<AccountId>,
 }
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
 pub struct ClusterProps<AccountId> {
 	pub node_provider_auth_contract: AccountId,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -20,6 +20,7 @@ pub struct ClusterParams<AccountId> {
 }
 
 // ClusterGovParams includes Governance sensetive parameters
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, PartialEq)]
 #[scale_info(skip_type_params(Balance, BlockNumber, T))]
 pub struct ClusterGovParams<Balance, BlockNumber> {


### PR DESCRIPTION
* `GenesisConfig` implementation for `pallet-ddc-clusters`.
* It skips `add_node` with checks and directly writes to the storage because currently cluster authorization smart contract is mandatory, but can't be set in in a genesis state (`pallet-contracts` does not implement `GenesisConfig`). Future implementation may make the extension contract optional and use `add_node` to check if the user set `ddc-staking` and `ddc-nodes` genesis consistently.