### PR TITLE
Add storage node mode to `example.json` chain spec

### DIFF
--- a/node/service/chain-specs/example.json
+++ b/node/service/chain-specs/example.json
@@ -189,7 +189,8 @@
               ],
               "http_port": 8080,
               "grpc_port": 8081,
-              "p2p_port": 8082
+              "p2p_port": 8082,
+              "mode": "Storage"
             }
           }
         ],


### PR DESCRIPTION
Related to https://github.com/Cerebellum-Network/blockchain-node/pull/200.

Tested manually with a local node.