### PR TITLE
DDC Storage node params updated with `domain` and `ssl` fields; Tests are enhanced

### DIFF
--- a/node/service/chain-specs/example.json
+++ b/node/service/chain-specs/example.json
@@ -187,6 +187,8 @@
                 46,
                 49
               ],
+              "domain": [],
+              "ssl": false,
               "http_port": 8080,
               "grpc_port": 8081,
               "p2p_port": 8082,

--- a/pallets/ddc-clusters/src/testing_utils.rs
+++ b/pallets/ddc-clusters/src/testing_utils.rs
@@ -55,7 +55,9 @@ where
 	let cluster_params = ClusterParams { node_provider_auth_contract: Some(user.clone()) };
 	let storage_node_params = StorageNodeParams {
 		mode: StorageNodeMode::Storage,
-		host: vec![1u8, 255],
+		host: vec![1u8; 255],
+		domain: vec![2u8; 255],
+		ssl: true,
 		http_port: 35000u16,
 		grpc_port: 25000u16,
 		p2p_port: 15000u16,

--- a/pallets/ddc-clusters/src/tests.rs
+++ b/pallets/ddc-clusters/src/tests.rs
@@ -58,6 +58,51 @@ fn create_cluster_works() {
 			cluster_gov_params.clone()
 		));
 
+		let created_cluster = DdcClusters::clusters(&cluster_id).unwrap();
+		assert_eq!(created_cluster.cluster_id, cluster_id);
+		assert_eq!(created_cluster.manager_id, cluster_manager_id);
+		assert_eq!(created_cluster.reserve_id, cluster_reserve_id);
+		assert_eq!(created_cluster.props.node_provider_auth_contract, Some(auth_contract.clone()));
+
+		let created_cluster_gov_params = DdcClusters::clusters_gov_params(&cluster_id).unwrap();
+		assert_eq!(created_cluster_gov_params.treasury_share, cluster_gov_params.treasury_share);
+		assert_eq!(
+			created_cluster_gov_params.validators_share,
+			cluster_gov_params.validators_share
+		);
+		assert_eq!(
+			created_cluster_gov_params.cluster_reserve_share,
+			cluster_gov_params.cluster_reserve_share
+		);
+		assert_eq!(
+			created_cluster_gov_params.storage_bond_size,
+			cluster_gov_params.storage_bond_size
+		);
+		assert_eq!(
+			created_cluster_gov_params.storage_chill_delay,
+			cluster_gov_params.storage_chill_delay
+		);
+		assert_eq!(
+			created_cluster_gov_params.storage_unbonding_delay,
+			cluster_gov_params.storage_unbonding_delay
+		);
+		assert_eq!(
+			created_cluster_gov_params.unit_per_mb_stored,
+			cluster_gov_params.unit_per_mb_stored
+		);
+		assert_eq!(
+			created_cluster_gov_params.unit_per_mb_streamed,
+			cluster_gov_params.unit_per_mb_streamed
+		);
+		assert_eq!(
+			created_cluster_gov_params.unit_per_put_request,
+			cluster_gov_params.unit_per_put_request
+		);
+		assert_eq!(
+			created_cluster_gov_params.unit_per_get_request,
+			cluster_gov_params.unit_per_get_request
+		);
+
 		// Creating cluster with same id should fail
 		assert_noop!(
 			DdcClusters::create_cluster(
@@ -144,7 +189,9 @@ fn add_and_delete_node_works() {
 
 		let storage_node_params = StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 255],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,
@@ -352,8 +399,11 @@ fn set_cluster_params_works() {
 		assert_ok!(DdcClusters::set_cluster_params(
 			RuntimeOrigin::signed(cluster_manager_id),
 			cluster_id,
-			ClusterParams { node_provider_auth_contract: Some(auth_contract_2) },
+			ClusterParams { node_provider_auth_contract: Some(auth_contract_2.clone()) },
 		));
+
+		let updated_cluster = DdcClusters::clusters(&cluster_id).unwrap();
+		assert_eq!(updated_cluster.props.node_provider_auth_contract, Some(auth_contract_2));
 
 		// Checking that event was emitted
 		assert_eq!(System::events().len(), 2);
@@ -412,11 +462,63 @@ fn set_cluster_gov_params_works() {
 			BadOrigin
 		);
 
+		let updated_gov_params = ClusterGovParams {
+			treasury_share: Perbill::from_float(0.06),
+			validators_share: Perbill::from_float(0.02),
+			cluster_reserve_share: Perbill::from_float(0.03),
+			storage_bond_size: 1000,
+			storage_chill_delay: 500,
+			storage_unbonding_delay: 500,
+			unit_per_mb_stored: 100,
+			unit_per_mb_streamed: 100,
+			unit_per_put_request: 100,
+			unit_per_get_request: 100,
+		};
+
 		assert_ok!(DdcClusters::set_cluster_gov_params(
 			RuntimeOrigin::root(),
 			cluster_id,
-			cluster_gov_params
+			updated_gov_params.clone()
 		));
+
+		let updated_cluster_gov_params = DdcClusters::clusters_gov_params(&cluster_id).unwrap();
+		assert_eq!(updated_cluster_gov_params.treasury_share, updated_gov_params.treasury_share);
+		assert_eq!(
+			updated_cluster_gov_params.validators_share,
+			updated_gov_params.validators_share
+		);
+		assert_eq!(
+			updated_cluster_gov_params.cluster_reserve_share,
+			updated_gov_params.cluster_reserve_share
+		);
+		assert_eq!(
+			updated_cluster_gov_params.storage_bond_size,
+			updated_gov_params.storage_bond_size
+		);
+		assert_eq!(
+			updated_cluster_gov_params.storage_chill_delay,
+			updated_gov_params.storage_chill_delay
+		);
+		assert_eq!(
+			updated_cluster_gov_params.storage_unbonding_delay,
+			updated_gov_params.storage_unbonding_delay
+		);
+		assert_eq!(
+			updated_cluster_gov_params.unit_per_mb_stored,
+			updated_gov_params.unit_per_mb_stored
+		);
+		assert_eq!(
+			updated_cluster_gov_params.unit_per_mb_streamed,
+			updated_gov_params.unit_per_mb_streamed
+		);
+		assert_eq!(
+			updated_cluster_gov_params.unit_per_put_request,
+			updated_gov_params.unit_per_put_request
+		);
+		assert_eq!(
+			updated_cluster_gov_params.unit_per_get_request,
+			updated_gov_params.unit_per_get_request
+		);
 
 		// Checking that event was emitted
 		assert_eq!(System::events().len(), 2);

--- a/pallets/ddc-clusters/src/tests.rs
+++ b/pallets/ddc-clusters/src/tests.rs
@@ -58,13 +58,13 @@ fn create_cluster_works() {
 			cluster_gov_params.clone()
 		));
 
-		let created_cluster = DdcClusters::clusters(&cluster_id).unwrap();
+		let created_cluster = DdcClusters::clusters(cluster_id).unwrap();
 		assert_eq!(created_cluster.cluster_id, cluster_id);
 		assert_eq!(created_cluster.manager_id, cluster_manager_id);
 		assert_eq!(created_cluster.reserve_id, cluster_reserve_id);
 		assert_eq!(created_cluster.props.node_provider_auth_contract, Some(auth_contract.clone()));
 
-		let created_cluster_gov_params = DdcClusters::clusters_gov_params(&cluster_id).unwrap();
+		let created_cluster_gov_params = DdcClusters::clusters_gov_params(cluster_id).unwrap();
 		assert_eq!(created_cluster_gov_params.treasury_share, cluster_gov_params.treasury_share);
 		assert_eq!(
 			created_cluster_gov_params.validators_share,
@@ -402,7 +402,7 @@ fn set_cluster_params_works() {
 			ClusterParams { node_provider_auth_contract: Some(auth_contract_2.clone()) },
 		));
 
-		let updated_cluster = DdcClusters::clusters(&cluster_id).unwrap();
+		let updated_cluster = DdcClusters::clusters(cluster_id).unwrap();
 		assert_eq!(updated_cluster.props.node_provider_auth_contract, Some(auth_contract_2));
 
 		// Checking that event was emitted
@@ -457,7 +457,7 @@ fn set_cluster_gov_params_works() {
 			DdcClusters::set_cluster_gov_params(
 				RuntimeOrigin::signed(cluster_manager_id),
 				cluster_id,
-				cluster_gov_params.clone()
+				cluster_gov_params
 			),
 			BadOrigin
 		);
@@ -481,7 +481,7 @@ fn set_cluster_gov_params_works() {
 			updated_gov_params.clone()
 		));
 
-		let updated_cluster_gov_params = DdcClusters::clusters_gov_params(&cluster_id).unwrap();
+		let updated_cluster_gov_params = DdcClusters::clusters_gov_params(cluster_id).unwrap();
 		assert_eq!(updated_cluster_gov_params.treasury_share, updated_gov_params.treasury_share);
 		assert_eq!(
 			updated_cluster_gov_params.validators_share,

--- a/pallets/ddc-nodes/src/benchmarking.rs
+++ b/pallets/ddc-nodes/src/benchmarking.rs
@@ -46,7 +46,9 @@ benchmarks! {
 			StorageNodePubKey::new([0; 32])).unwrap().props,
 			StorageNodeProps {
 				mode: StorageNodeMode::Storage,
-				host: vec![2u8, 255].try_into().unwrap(),
+				host: vec![3u8; 255].try_into().unwrap(),
+				domain: vec![4u8; 255].try_into().unwrap(),
+				ssl: true,
 				http_port: 45000u16,
 				grpc_port: 55000u16,
 				p2p_port: 65000u16,

--- a/pallets/ddc-nodes/src/lib.rs
+++ b/pallets/ddc-nodes/src/lib.rs
@@ -75,6 +75,7 @@ pub mod pallet {
 		OnlyNodeProvider,
 		NodeIsAssignedToCluster,
 		HostLenExceedsLimit,
+		DomainLenExceedsLimit,
 		NodeHasDanglingStake,
 	}
 

--- a/pallets/ddc-nodes/src/node.rs
+++ b/pallets/ddc-nodes/src/node.rs
@@ -92,12 +92,14 @@ impl<T: frame_system::Config> NodeTrait<T> for Node<T> {
 #[derive(Debug, PartialEq)]
 pub enum NodeError {
 	StorageHostLenExceedsLimit,
+	StorageDomainLenExceedsLimit,
 }
 
 impl<T> From<NodeError> for Error<T> {
 	fn from(error: NodeError) -> Self {
 		match error {
 			NodeError::StorageHostLenExceedsLimit => Error::<T>::HostLenExceedsLimit,
+			NodeError::StorageDomainLenExceedsLimit => Error::<T>::DomainLenExceedsLimit,
 		}
 	}
 }

--- a/pallets/ddc-nodes/src/testing_utils.rs
+++ b/pallets/ddc-nodes/src/testing_utils.rs
@@ -17,7 +17,9 @@ pub fn create_user_and_config<T: Config>(
 	let node = NodePubKey::StoragePubKey(StorageNodePubKey::new([0; 32]));
 	let storage_node_params = NodeParams::StorageParams(StorageNodeParams {
 		mode: StorageNodeMode::Storage,
-		host: vec![1u8, 255],
+		host: vec![1u8; 255],
+		domain: vec![2u8; 255],
+		ssl: false,
 		http_port: 35000u16,
 		grpc_port: 25000u16,
 		p2p_port: 15000u16,
@@ -25,7 +27,9 @@ pub fn create_user_and_config<T: Config>(
 
 	let new_storage_node_params = NodeParams::StorageParams(StorageNodeParams {
 		mode: StorageNodeMode::Storage,
-		host: vec![2u8, 255],
+		host: vec![3u8; 255],
+		domain: vec![4u8; 255],
+		ssl: true,
 		http_port: 45000u16,
 		grpc_port: 55000u16,
 		p2p_port: 65000u16,

--- a/pallets/ddc-nodes/src/tests.rs
+++ b/pallets/ddc-nodes/src/tests.rs
@@ -3,6 +3,7 @@
 use ddc_primitives::{NodePubKey, StorageNodeMode, StorageNodeParams};
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::AccountId32;
+use storage_node::{MaxDomainLen, MaxHostLen};
 
 use super::{mock::*, *};
 
@@ -14,7 +15,9 @@ fn create_storage_node_works() {
 		let node_pub_key = AccountId32::from(bytes);
 		let storage_node_params = StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 255],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,
@@ -28,6 +31,8 @@ fn create_storage_node_works() {
 				NodeParams::StorageParams(StorageNodeParams {
 					mode: StorageNodeMode::Storage,
 					host: vec![1u8; 256],
+					domain: vec![2u8; 255],
+					ssl: true,
 					http_port: 35000u16,
 					grpc_port: 25000u16,
 					p2p_port: 15000u16,
@@ -36,12 +41,47 @@ fn create_storage_node_works() {
 			Error::<Test>::HostLenExceedsLimit
 		);
 
+		// Host length exceeds limit
+		assert_noop!(
+			DdcNodes::create_node(
+				RuntimeOrigin::signed(1),
+				NodePubKey::StoragePubKey(node_pub_key.clone()),
+				NodeParams::StorageParams(StorageNodeParams {
+					mode: StorageNodeMode::Storage,
+					host: vec![1u8; 255],
+					domain: vec![2u8; 256],
+					ssl: true,
+					http_port: 35000u16,
+					grpc_port: 25000u16,
+					p2p_port: 15000u16,
+				})
+			),
+			Error::<Test>::DomainLenExceedsLimit
+		);
+
 		// Node created
 		assert_ok!(DdcNodes::create_node(
 			RuntimeOrigin::signed(1),
 			NodePubKey::StoragePubKey(node_pub_key.clone()),
 			NodeParams::StorageParams(storage_node_params.clone())
 		));
+
+		let created_storage_node = DdcNodes::storage_nodes(&node_pub_key).unwrap();
+		let expected_host: BoundedVec<u8, MaxHostLen> =
+			storage_node_params.clone().host.try_into().unwrap();
+		let expected_domain: BoundedVec<u8, MaxDomainLen> =
+			storage_node_params.clone().domain.try_into().unwrap();
+
+		assert_eq!(created_storage_node.pub_key, node_pub_key);
+		assert_eq!(created_storage_node.provider_id, 1);
+		assert_eq!(created_storage_node.cluster_id, None);
+		assert_eq!(created_storage_node.props.host, expected_host);
+		assert_eq!(created_storage_node.props.domain, expected_domain);
+		assert_eq!(created_storage_node.props.ssl, storage_node_params.ssl);
+		assert_eq!(created_storage_node.props.http_port, storage_node_params.http_port);
+		assert_eq!(created_storage_node.props.grpc_port, storage_node_params.grpc_port);
+		assert_eq!(created_storage_node.props.p2p_port, storage_node_params.p2p_port);
+		assert_eq!(created_storage_node.props.mode, storage_node_params.mode);
 
 		// Check storage
 		assert!(StorageNodes::<Test>::contains_key(node_pub_key.clone()));
@@ -80,7 +120,9 @@ fn create_storage_node_with_node_creator() {
 		let node_pub_key = AccountId32::from(bytes);
 		let storage_node_params = StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 255],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,
@@ -114,7 +156,9 @@ fn set_storage_node_params_works() {
 		let node_pub_key = AccountId32::from(bytes);
 		let storage_node_params = StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 255],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,
@@ -137,12 +181,38 @@ fn set_storage_node_params_works() {
 			NodeParams::StorageParams(storage_node_params.clone())
 		));
 
+		let updated_params = StorageNodeParams {
+			mode: StorageNodeMode::Full,
+			host: vec![3u8; 255],
+			domain: vec![4u8; 255],
+			ssl: false,
+			http_port: 35000u16,
+			grpc_port: 25000u16,
+			p2p_port: 15000u16,
+		};
+
 		// Set node params
 		assert_ok!(DdcNodes::set_node_params(
 			RuntimeOrigin::signed(1),
 			NodePubKey::StoragePubKey(node_pub_key.clone()),
-			NodeParams::StorageParams(storage_node_params.clone())
+			NodeParams::StorageParams(updated_params.clone())
 		));
+
+		let updated_storage_node = DdcNodes::storage_nodes(&node_pub_key).unwrap();
+		let expected_host: BoundedVec<u8, MaxHostLen> = updated_params.host.try_into().unwrap();
+		let expected_domain: BoundedVec<u8, MaxDomainLen> =
+			updated_params.domain.try_into().unwrap();
+
+		assert_eq!(updated_storage_node.pub_key, node_pub_key);
+		assert_eq!(updated_storage_node.provider_id, 1);
+		assert_eq!(updated_storage_node.cluster_id, None);
+		assert_eq!(updated_storage_node.props.host, expected_host);
+		assert_eq!(updated_storage_node.props.domain, expected_domain);
+		assert_eq!(updated_storage_node.props.ssl, updated_params.ssl);
+		assert_eq!(updated_storage_node.props.http_port, updated_params.http_port);
+		assert_eq!(updated_storage_node.props.grpc_port, updated_params.grpc_port);
+		assert_eq!(updated_storage_node.props.p2p_port, updated_params.p2p_port);
+		assert_eq!(updated_storage_node.props.mode, updated_params.mode);
 
 		// Only node provider can set params
 		assert_noop!(
@@ -177,12 +247,32 @@ fn set_storage_node_params_works() {
 				NodeParams::StorageParams(StorageNodeParams {
 					mode: StorageNodeMode::Storage,
 					host: vec![1u8; 256],
+					domain: vec![2u8; 255],
+					ssl: true,
 					http_port: 35000u16,
 					grpc_port: 25000u16,
 					p2p_port: 15000u16,
 				})
 			),
 			Error::<Test>::HostLenExceedsLimit
+		);
+
+		// Storage domain length exceeds limit
+		assert_noop!(
+			DdcNodes::set_node_params(
+				RuntimeOrigin::signed(1),
+				NodePubKey::StoragePubKey(node_pub_key.clone()),
+				NodeParams::StorageParams(StorageNodeParams {
+					mode: StorageNodeMode::Storage,
+					host: vec![1u8; 255],
+					domain: vec![2u8; 256],
+					ssl: true,
+					http_port: 35000u16,
+					grpc_port: 25000u16,
+					p2p_port: 15000u16,
+				})
+			),
+			Error::<Test>::DomainLenExceedsLimit
 		);
 
 		// Checking that event was emitted
@@ -202,7 +292,9 @@ fn delete_storage_node_works() {
 		let node_pub_key = AccountId32::from(bytes);
 		let storage_node_params = StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 255],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,

--- a/pallets/ddc-staking/src/benchmarking.rs
+++ b/pallets/ddc-staking/src/benchmarking.rs
@@ -27,7 +27,9 @@ benchmarks! {
 			stash.clone(),
 			NodeParams::StorageParams(StorageNodeParams {
 				mode: StorageNodeMode::Storage,
-				host: vec![1u8, 255],
+				host: vec![1u8; 255],
+				domain: vec![2u8; 256],
+				ssl: true,
 				http_port: 35000u16,
 				grpc_port: 25000u16,
 				p2p_port: 15000u16,

--- a/pallets/ddc-staking/src/testing_utils.rs
+++ b/pallets/ddc-staking/src/testing_utils.rs
@@ -62,7 +62,9 @@ pub fn create_stash_controller_node<T: Config>(
 		stash.clone(),
 		NodeParams::StorageParams(StorageNodeParams {
 			mode: StorageNodeMode::Storage,
-			host: vec![1u8, 255],
+			host: vec![1u8; 255],
+			domain: vec![2u8; 256],
+			ssl: true,
 			http_port: 35000u16,
 			grpc_port: 25000u16,
 			p2p_port: 15000u16,
@@ -97,7 +99,9 @@ pub fn create_stash_controller_node_with_balance<T: Config>(
 				stash.clone(),
 				NodeParams::StorageParams(StorageNodeParams {
 					mode: StorageNodeMode::Storage,
-					host: vec![1u8, 255],
+					host: vec![1u8; 255],
+					domain: vec![2u8; 256],
+					ssl: true,
 					http_port: 35000u16,
 					grpc_port: 25000u16,
 					p2p_port: 15000u16,

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -100,6 +100,8 @@ pub enum StorageNodeMode {
 pub struct StorageNodeParams {
 	pub mode: StorageNodeMode,
 	pub host: Vec<u8>,
+	pub domain: Vec<u8>,
+	pub ssl: bool,
 	pub http_port: u16,
 	pub grpc_port: u16,
 	pub p2p_port: u16,


### PR DESCRIPTION
This PR introduces `domain` and `ssl` fields for storage node params