### PR TITLE
Configure chain properties for dev runtime

### DIFF
--- a/node/service/src/chain_spec.rs
+++ b/node/service/src/chain_spec.rs
@@ -4,6 +4,7 @@ use cere_dev_runtime as cere_dev;
 use cere_dev_runtime_constants::currency::DOLLARS as TEST_UNITS;
 #[cfg(feature = "cere-native")]
 use cere_runtime as cere;
+use jsonrpsee::core::__reexports::serde_json;
 pub use node_primitives::{AccountId, Balance, Block, Signature};
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_chain_spec::ChainSpecExtension;
@@ -239,6 +240,18 @@ pub fn cere_dev_genesis(
 	}
 }
 
+/// Returns the properties for the [`cere-dev-native`].
+pub fn cere_dev_native_chain_spec_properties() -> serde_json::map::Map<String, serde_json::Value> {
+	serde_json::json!({
+		"tokenDecimals": 10,
+		"tokenSymbol": "CERE",
+		"ss58Format": 54,
+	})
+	.as_object()
+	.expect("Map given; qed")
+	.clone()
+}
+
 /// Helper function to create Cere `GenesisConfig` for testing
 #[cfg(feature = "cere-dev-native")]
 fn cere_dev_config_genesis(wasm_binary: &[u8]) -> cere_dev::GenesisConfig {
@@ -273,7 +286,7 @@ pub fn cere_dev_development_config() -> Result<CereDevChainSpec, String> {
 		None,
 		Some(DEFAULT_PROTOCOL_ID),
 		None,
-		None,
+		Some(cere_dev_native_chain_spec_properties()),
 		Default::default(),
 	))
 }


### PR DESCRIPTION
Fix the issue @yahortsaryk reported in [Slack](https://cere-network.slack.com/archives/C04S79C3A11/p1703786484555029).

The issue was caused by misconfiguration of `dev` chain spec