### PR TITLE
Hotfix: Disable burn on 0.9.40

### DIFF
--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -904,7 +904,7 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 50_000 * DOLLARS;
 	pub const SpendPeriod: BlockNumber = DAYS;
-	pub const Burn: Permill = Permill::from_parts(580);
+	pub const Burn: Permill = Permill::from_percent(0);
 	pub const TipCountdown: BlockNumber = DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: Balance = 50_000 * DOLLARS;


### PR DESCRIPTION
### Description
<!-- Describe what change this PR is implementing -->
DO NOT MERGE. 

This hotfix will be used for a runtime upgrade to 0.9.40 without the burn enabled.

### Types of Changes
<!--- What types of changes does your code introduce? -->
- [ ] Tech Debt (Code improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade (A change in substrate or any 3rd party crate version)

### Migrations and Hooks
<!--- Check the following box with an x if the following applies: -->
- [ ] This change requires a runtime migration.
- [ ] Modifies `on_initialize`
- [ ] Modifies `on_finalize`

### Checklist
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been tested locally.
- [ ] Change adds / updates tests.
- [ ] Changelog doc updated.
