### PR TITLE
Reorder migrations

### DIFF
--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1515,6 +1515,10 @@ impl OnRuntimeUpgrade for SetStorageVersions {
 }
 /// Runtime migrations
 type Migrations = (
+	// Contracts migrate in sequence so make them last.
+	// Substrate upgrades run in reverse order so this migration
+	// is the last one to execute.
+	pallet_contracts::migration::Migration<Runtime>,
 	pallet_im_online::migration::v1::Migration<Runtime>,
 	pallet_democracy::migrations::v1::v1::Migration<Runtime>,
 	pallet_fast_unstake::migrations::v1::MigrateToV1<Runtime>,
@@ -1524,7 +1528,6 @@ type Migrations = (
 	pallet_staking::migrations::v10::MigrateToV10<Runtime>,
 	pallet_staking::migrations::v13::MigrateToV13<Runtime>,
 	pallet_society::migrations::MigrateToV2<Runtime, (), ()>,
-	pallet_contracts::migration::Migration<Runtime>,
 	pallet_ddc_customers::migration::MigrateToV1<Runtime>,
 	SetStorageVersions,
 );


### PR DESCRIPTION
### Description
<!-- Describe what change this PR is implementing -->

Contracts pallet executes migrations in sequence depending on weight available. If not, it schedules a multi-block migration sequence. It's better to have it execute last.

### Types of Changes
<!--- What types of changes does your code introduce? -->
- [ ] Tech Debt (Code improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade (A change in substrate or any 3rd party crate version)

### Migrations and Hooks
<!--- Check the following box with an x if the following applies: -->
- [ ] This change requires a runtime migration.
- [ ] Modifies `on_initialize`
- [ ] Modifies `on_finalize`

### Checklist
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been tested locally.
- [ ] Change adds / updates tests.
- [ ] Changelog doc updated.
