### PR TITLE
Update `ci.yaml` runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   format:
     name: Check Lints
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
   check:
     name: Cargo check
     needs: format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Install linux dependencies
@@ -72,7 +72,7 @@ jobs:
   clippy:
     name: Run Clippy
     needs: format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Install linux dependencies

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -149,7 +149,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 60002,
+	spec_version: 60003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 20,


### PR DESCRIPTION
## Description

The path updates `ci.yaml` workflow runners to Ubuntu 24.04 already used for the other workflows. It brings a more recent `protoc` package need for https://github.com/Cerebellum-Network/blockchain-node/pull/458.