### PR TITLE
Specify `ci.yaml` workflow trigger paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ '**' ]
+    paths:
+      - '**.lock'
+      - '**.toml'
+      - 'node/**'
+      - 'pallets/**'
+      - 'primitives/**'
+      - 'runtime/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Description

Workflow `ci.yaml` only makes sense on changes to a client or a runtime code. Otherwise there should not be an expensive workflow run and a protective guard against a patch.

Required for https://github.com/Cerebellum-Network/blockchain-node/pull/461.