### PR TITLE
Fix `ddc-primitives` missing import check error

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -323,7 +323,8 @@ pub mod sr25519 {
 	mod app_sr25519 {
 		use sp_application_crypto::{app_crypto, sr25519};
 
-		use crate::DAC_VERIFICATION_KEY_TYPE;
+		use crate::{String, DAC_VERIFICATION_KEY_TYPE};
+
 		app_crypto!(sr25519, DAC_VERIFICATION_KEY_TYPE);
 	}
 
@@ -342,7 +343,8 @@ pub mod crypto {
 		MultiSignature, MultiSigner,
 	};
 
-	use super::DAC_VERIFICATION_KEY_TYPE;
+	use crate::{String, DAC_VERIFICATION_KEY_TYPE};
+
 	app_crypto!(sr25519, DAC_VERIFICATION_KEY_TYPE);
 	pub struct OffchainIdentifierId;
 	impl frame_system::offchain::AppCrypto<MultiSigner, MultiSignature> for OffchainIdentifierId {


### PR DESCRIPTION
## Description

The current version fails at `cargo check` for a single crate with the following error.

<details>

<summary>$ cargo check -p pallet-ddc-verification</summary>


```console
$ cargo check -p pallet-ddc-verification
    Checking ddc-primitives v6.1.0 (/home/khassanov/Workspace/github.com/Cerebellum-Network/blockchain-node/primitives)
error[E0412]: cannot find type `String` in this scope
   --> primitives/src/lib.rs:327:3
    |
327 |         app_crypto!(sr25519, DAC_VERIFICATION_KEY_TYPE);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `$crate::app_crypto_pair_functions_if_std` which comes from the expansion of the macro `app_crypto` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
    |
324 +         use crate::String;
    |
324 +         use scale_info::prelude::string::String;
    |

error[E0412]: cannot find type `String` in this scope
   --> primitives/src/lib.rs:346:2
    |
346 |     app_crypto!(sr25519, DAC_VERIFICATION_KEY_TYPE);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `$crate::app_crypto_pair_functions_if_std` which comes from the expansion of the macro `app_crypto` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
    |
338 +     use crate::String;
    |
338 +     use scale_info::prelude::string::String;
    |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `ddc-primitives` (lib) due to 2 previous errors
```
</details>

## Types of Changes
Please select the branch type you are merging and fill in the relevant template.
<!--- Check the following box with an x if the following applies: -->
- [ ] Hotfix
- [ ] Release
- [x] Fix or Feature

## Fix or Feature
<!--- Check the following box with an x if the following applies: -->

### Types of Changes
<!--- What types of changes does your code introduce? -->
- [ ] Tech Debt (Code improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade (A change in substrate or any 3rd party crate version)

### Migrations and Hooks
<!--- Check the following box with an x if the following applies: -->
- [ ] This change requires a runtime migration.
- [ ] Modifies `on_initialize`
- [ ] Modifies `on_finalize`

### Checklist for Fix or Feature
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [x] Change has been tested locally.
- [ ] Change adds / updates tests if applicable.
- [ ] Changelog doc updated.
- [ ] `spec_version` has been incremented.
- [ ] `network-relayer`'s [events](https://github.com/Cerebellum-Network/network-relayer/blob/dev-cere/shared/substrate/events.go) have been updated according to the blockchain events if applicable.
- [ ] All CI checks have been passed successfully

## Checklist for Hotfix
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been deployed to Testnet.
- [ ] Change has been tested in Testnet.
- [ ] Changelog has been updated.
- [ ] Crate version has been updated.
- [ ] `spec_version` has been incremented.
- [ ] Transaction version has been updated if required.
- [ ] Pull Request to `dev` has been created.
- [ ] Pull Request to `staging` has been created.
- [ ] `network-relayer`'s [events](https://github.com/Cerebellum-Network/network-relayer/blob/dev-cere/shared/substrate/events.go) have been updated according to the blockchain events if applicable.
- [ ] All CI checks have been passed successfully

## Checklist for Release
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been deployed to Devnet.
- [ ] Change has been tested in Devnet.
- [ ] Change has been deployed to Qanet.
- [ ] Change has been tested in Qanet.
- [ ] Change has been deployed to Testnet.
- [ ] Change has been tested in Testnet.
- [ ] Changelog has been updated.
- [ ] Crate version has been updated.
- [ ] Spec version has been updated.
- [ ] Transaction version has been updated if required.
- [ ] All CI checks have been passed successfully
