### PR TITLE
Restoring Sandbox Host Functions for Node Synchronization in Full Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ version = "6.6.1"
 dependencies = [
  "cere-dev-runtime",
  "cere-runtime",
+ "cere-runtime-interfaces",
  "frame-benchmarking",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -1140,6 +1141,17 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
+]
+
+[[package]]
+name = "cere-runtime-interfaces"
+version = "6.6.1"
+dependencies = [
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-runtime-interface-proc-macro",
+ "sp-wasm-interface",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
 name = "cere-runtime-interfaces"
 version = "6.6.1"
 dependencies = [
+ "environmental",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor",
@@ -1156,7 +1157,7 @@ dependencies = [
  "sp-runtime-interface-proc-macro",
  "sp-std",
  "sp-wasm-interface",
- "wasmi 0.31.2",
+ "wasmi 0.13.2",
 ]
 
 [[package]]
@@ -4739,6 +4740,12 @@ checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
 ]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -11362,15 +11369,13 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.31.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
 dependencies = [
- "smallvec",
- "spin 0.9.8",
- "wasmi_arena",
- "wasmi_core 0.13.0",
- "wasmparser-nostd",
+ "parity-wasm",
+ "wasmi-validation",
+ "wasmi_core 0.2.1",
 ]
 
 [[package]]
@@ -11391,10 +11396,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmi_arena"
-version = "0.4.1"
+name = "wasmi-validation"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
+dependencies = [
+ "parity-wasm",
+]
 
 [[package]]
 name = "wasmi_collections"
@@ -11409,14 +11417,15 @@ dependencies = [
 
 [[package]]
 name = "wasmi_core"
-version = "0.13.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+checksum = "57d20cb3c59b788653d99541c646c561c9dd26506f25c0cebfe810659c54c6d7"
 dependencies = [
  "downcast-rs",
  "libm",
+ "memory_units",
+ "num-rational",
  "num-traits",
- "paste",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,9 +1148,13 @@ name = "cere-runtime-interfaces"
 version = "6.6.1"
 dependencies = [
  "parity-scale-codec",
+ "sc-allocator",
+ "sc-executor",
+ "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
  "sp-runtime-interface-proc-macro",
+ "sp-std",
  "sp-wasm-interface",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,7 @@ name = "cere-runtime-interfaces"
 version = "6.6.1"
 dependencies = [
  "environmental",
+ "log",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor",
@@ -1157,6 +1158,7 @@ dependencies = [
  "sp-runtime-interface-proc-macro",
  "sp-std",
  "sp-wasm-interface",
+ "thiserror",
  "wasmi 0.13.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "sp-runtime-interface-proc-macro",
  "sp-std",
  "sp-wasm-interface",
+ "wasmi 0.31.2",
 ]
 
 [[package]]
@@ -5587,7 +5588,7 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
- "wasmi",
+ "wasmi 0.32.3",
 ]
 
 [[package]]
@@ -11361,6 +11362,19 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+dependencies = [
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_arena",
+ "wasmi_core 0.13.0",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
@@ -11372,9 +11386,15 @@ dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_collections",
- "wasmi_core",
+ "wasmi_core 0.32.3",
  "wasmparser-nostd",
 ]
+
+[[package]]
+name = "wasmi_arena"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_collections"
@@ -11385,6 +11405,18 @@ dependencies = [
  "ahash",
  "hashbrown 0.14.5",
  "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
   "primitives",
   "runtime/cere",
   "runtime/cere-dev",
+	"node/runtime-interfaces",
+
 ]
 resolver = "2"
 
@@ -156,6 +158,8 @@ sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "p
 sp-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
+sp-runtime-interface-proc-macro = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-session = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
@@ -167,6 +171,7 @@ sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk.git", 
 sp-transaction-storage-proof = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-trie = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sp-version = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
+sp-wasm-interface = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 substrate-state-trie-migration-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
@@ -179,6 +184,7 @@ cere-dev-runtime = { path = "runtime/cere-dev" }
 cere-rpc = { path = "node/rpc" }
 cere-runtime = { path = "runtime/cere" }
 cere-runtime-common = { path = "runtime/common", default-features = false }
+cere-runtime-interfaces = { path = "node/runtime-interfaces" }
 cere-service = { path = "node/service" }
 ddc-primitives = { path = "primitives", default-features = false }
 pallet-chainbridge = { path = "pallets/chainbridge", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git",
 sc-consensus-grandpa-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sc-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
+sc-allocator = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
 sc-network = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }
 sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409", default-features = false }

--- a/node/client/Cargo.toml
+++ b/node/client/Cargo.toml
@@ -41,6 +41,7 @@ sp-transaction-pool = { workspace = true, default-features = true }
 # Local
 cere-dev-runtime = { workspace = true, optional = true }
 cere-runtime = { workspace = true, optional = true }
+cere-runtime-interfaces = { workspace = true }
 
 [features]
 default = ["cere"]

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -20,11 +20,11 @@ use sp_storage::{ChildInfo, StorageData, StorageKey};
 pub type FullBackend = sc_service::TFullBackend<Block>;
 
 #[cfg(not(feature = "runtime-benchmarks"))]
-pub type HostFunctions = sp_io::SubstrateHostFunctions;
+pub type HostFunctions = (sp_io::SubstrateHostFunctions,cere_runtime_interfaces::sandbox::HostFunctions);
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type HostFunctions =
-	(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
+	(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions,cere_runtime_interfaces::sandbox::HostFunctions);
 
 pub type ChainExecutor = WasmExecutor<HostFunctions>;
 pub type FullClient<RuntimeApi> = sc_service::TFullClient<Block, RuntimeApi, ChainExecutor>;

--- a/node/runtime-interfaces/Cargo.toml
+++ b/node/runtime-interfaces/Cargo.toml
@@ -13,6 +13,11 @@ sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
 sp-runtime-interface-proc-macro = { workspace = true }
 sp-wasm-interface = { workspace = true }
+sp-std = { workspace = true }
+sp-core = { workspace = true }
+sc-allocator = { workspace = true }
+sc-executor = { workspace = true }
+
 [features]
 default = [ "std" ]
 std = [

--- a/node/runtime-interfaces/Cargo.toml
+++ b/node/runtime-interfaces/Cargo.toml
@@ -17,7 +17,8 @@ sp-std = { workspace = true }
 sp-core = { workspace = true }
 sc-allocator = { workspace = true }
 sc-executor = { workspace = true }
-wasmi = "0.31.0"
+wasmi = "0.13"
+environmental = "1.1.3"
 
 [features]
 default = [ "std" ]

--- a/node/runtime-interfaces/Cargo.toml
+++ b/node/runtime-interfaces/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cere-runtime-interfaces"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+[dependencies]
+codec = { workspace = true }
+sp-runtime = { workspace = true }
+sp-runtime-interface = { workspace = true }
+sp-runtime-interface-proc-macro = { workspace = true }
+sp-wasm-interface = { workspace = true }
+[features]
+default = [ "std" ]
+std = [
+	"sp-runtime/std",
+	"sp-runtime-interface/std",
+	"sp-wasm-interface/std",
+]

--- a/node/runtime-interfaces/Cargo.toml
+++ b/node/runtime-interfaces/Cargo.toml
@@ -17,6 +17,7 @@ sp-std = { workspace = true }
 sp-core = { workspace = true }
 sc-allocator = { workspace = true }
 sc-executor = { workspace = true }
+wasmi = "0.31.0"
 
 [features]
 default = [ "std" ]

--- a/node/runtime-interfaces/Cargo.toml
+++ b/node/runtime-interfaces/Cargo.toml
@@ -19,6 +19,9 @@ sc-allocator = { workspace = true }
 sc-executor = { workspace = true }
 wasmi = "0.13"
 environmental = "1.1.3"
+log = {workspace = true}
+thiserror = { version = "1.0.48" }
+
 
 [features]
 default = [ "std" ]

--- a/node/runtime-interfaces/src/env.rs
+++ b/node/runtime-interfaces/src/env.rs
@@ -1,0 +1,120 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Definition of a sandbox environment.
+
+use codec::{Decode, Encode};
+
+use sp_core::RuntimeDebug;
+use sp_std::vec::Vec;
+
+/// Error error that can be returned from host function.
+#[derive(Encode, Decode, RuntimeDebug)]
+pub struct HostError;
+
+/// Describes an entity to define or import into the environment.
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+pub enum ExternEntity {
+	/// Function that is specified by an index in a default table of
+	/// a module that creates the sandbox.
+	#[codec(index = 1)]
+	Function(u32),
+
+	/// Linear memory that is specified by some identifier returned by sandbox
+	/// module upon creation new sandboxed memory.
+	#[codec(index = 2)]
+	Memory(u32),
+}
+
+/// An entry in a environment definition table.
+///
+/// Each entry has a two-level name and description of an entity
+/// being defined.
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+pub struct Entry {
+	/// Module name of which corresponding entity being defined.
+	pub module_name: Vec<u8>,
+	/// Field name in which corresponding entity being defined.
+	pub field_name: Vec<u8>,
+	/// External entity being defined.
+	pub entity: ExternEntity,
+}
+
+/// Definition of runtime that could be used by sandboxed code.
+#[derive(Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
+pub struct EnvironmentDefinition {
+	/// Vector of all entries in the environment definition.
+	pub entries: Vec<Entry>,
+}
+
+/// Constant for specifying no limit when creating a sandboxed
+/// memory instance. For FFI purposes.
+pub const MEM_UNLIMITED: u32 = -1i32 as u32;
+
+/// No error happened.
+///
+/// For FFI purposes.
+pub const ERR_OK: u32 = 0;
+
+/// Validation or instantiation error occurred when creating new
+/// sandboxed module instance.
+///
+/// For FFI purposes.
+pub const ERR_MODULE: u32 = -1i32 as u32;
+
+/// Out-of-bounds access attempted with memory or table.
+///
+/// For FFI purposes.
+pub const ERR_OUT_OF_BOUNDS: u32 = -2i32 as u32;
+
+/// Execution error occurred (typically trap).
+///
+/// For FFI purposes.
+pub const ERR_EXECUTION: u32 = -3i32 as u32;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::Codec;
+	use std::fmt;
+
+	fn roundtrip<S: Codec + PartialEq + fmt::Debug>(s: S) {
+		let encoded = s.encode();
+		assert_eq!(S::decode(&mut &encoded[..]).unwrap(), s);
+	}
+
+	#[test]
+	fn env_def_roundtrip() {
+		roundtrip(EnvironmentDefinition { entries: vec![] });
+
+		roundtrip(EnvironmentDefinition {
+			entries: vec![Entry {
+				module_name: b"kernel"[..].into(),
+				field_name: b"memory"[..].into(),
+				entity: ExternEntity::Memory(1337),
+			}],
+		});
+
+		roundtrip(EnvironmentDefinition {
+			entries: vec![Entry {
+				module_name: b"env"[..].into(),
+				field_name: b"abort"[..].into(),
+				entity: ExternEntity::Function(228),
+			}],
+		});
+	}
+}

--- a/node/runtime-interfaces/src/freeing_bump.rs
+++ b/node/runtime-interfaces/src/freeing_bump.rs
@@ -1,0 +1,620 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module implements a freeing-bump allocator.
+//!
+//! The heap is a continuous linear memory and chunks are allocated using a bump allocator.
+//!
+//! ```ignore
+//! +-------------+-------------------------------------------------+
+//! | <allocated> | <unallocated>                                   |
+//! +-------------+-------------------------------------------------+
+//!               ^
+//!               |_ bumper
+//! ```
+//!
+//! Only allocations with sizes of power of two can be allocated. If the incoming request has a non
+//! power of two size it is increased to the nearest power of two. The power of two of size is
+//! referred as **an order**.
+//!
+//! Each allocation has a header immediately preceding to it. The header is always 8 bytes and can
+//! be of two types: free and occupied.
+//!
+//! For implementing freeing we maintain a linked lists for each order. The maximum supported
+//! allocation size is capped, therefore the number of orders and thus the linked lists is as well
+//! limited. Currently, the maximum size of an allocation is 32 MiB.
+//!
+//! When the allocator serves an allocation request it first checks the linked list for the
+//! respective order. If it doesn't have any free chunks, the allocator requests memory from the
+//! bump allocator. In any case the order is stored in the header of the allocation.
+//!
+//! Upon deallocation we get the order of the allocation from its header and then add that
+//! allocation to the linked list for the respective order.
+//!
+//! # Caveats
+//!
+//! This is a fast allocator but it is also dumb. There are specifically two main shortcomings
+//! that the user should keep in mind:
+//!
+//! - Once the bump allocator space is exhausted, there is no way to reclaim the memory. This means
+//!   that it's possible to end up in a situation where there are no live allocations yet a new
+//!   allocation will fail.
+//!
+//!   Let's look into an example. Given a heap of 32 MiB. The user makes a 32 MiB allocation that we
+//!   call `X` . Now the heap is full. Then user deallocates `X`. Since all the space in the bump
+//!   allocator was consumed by the 32 MiB allocation, allocations of all sizes except 32 MiB will
+//!   fail.
+//!
+//! - Sizes of allocations are rounded up to the nearest order. That is, an allocation of 2,00001
+//!   MiB will be put into the bucket of 4 MiB. Therefore, any allocation of size `(N, 2N]` will
+//!   take up to `2N`, thus assuming a uniform distribution of allocation sizes, the average amount
+//!   in use of a `2N` space on the heap will be `(3N + ε) / 2`. So average utilization is going to
+//!   be around 75% (`(3N + ε) / 2 / 2N`) meaning that around 25% of the space in allocation will be
+//!   wasted. This is more pronounced (in terms of absolute heap amounts) with larger allocation
+//!   sizes.
+
+pub use sp_core::MAX_POSSIBLE_ALLOCATION;
+use sp_wasm_interface::{Pointer, WordSize};
+use std::{
+	cmp::{max, min},
+	mem,
+	ops::{Index, IndexMut, Range},
+};
+
+/// The minimal alignment guaranteed by this allocator.
+///
+/// The alignment of 8 is chosen because it is the maximum size of a primitive type supported by the
+/// target version of wasm32: i64's natural alignment is 8.
+const ALIGNMENT: u32 = 8;
+
+// Each pointer is prefixed with 8 bytes, which identify the list index
+// to which it belongs.
+const HEADER_SIZE: u32 = 8;
+
+/// The error type used by the allocators.
+#[derive(thiserror::Error, Debug)]
+pub enum FreeBumpError {
+	/// Someone tried to allocate more memory than the allowed maximum per allocation.
+	#[error("Requested allocation size is too large")]
+	RequestedAllocationTooLarge,
+	/// Allocator run out of space.
+	#[error("Allocator ran out of space")]
+	AllocatorOutOfSpace,
+	/// The client passed a memory instance which is smaller than previously observed.
+	#[error("Shrinking of the underlying memory is observed")]
+	MemoryShrinked,
+	/// Some other error occurred.
+	#[error("Other: {0}")]
+	Other(&'static str),
+}
+
+/// Create an allocator error.
+fn error(msg: &'static str) -> FreeBumpError {
+	FreeBumpError::Other(msg)
+}
+
+const LOG_TARGET: &str = "wasm-heap";
+
+// The minimum possible allocation size is chosen to be 8 bytes because in that case we would have
+// easier time to provide the guaranteed alignment of 8.
+//
+// The maximum possible allocation size is set in the primitives to 32MiB.
+//
+// N_ORDERS - represents the number of orders supported.
+//
+// This number corresponds to the number of powers between the minimum possible allocation and
+// maximum possible allocation, or: 2^3...2^25 (both ends inclusive, hence 23).
+const N_ORDERS: usize = 23;
+const MIN_POSSIBLE_ALLOCATION: u32 = 8; // 2^3 bytes, 8 bytes
+
+/// The exponent for the power of two sized block adjusted to the minimum size.
+///
+/// This way, if `MIN_POSSIBLE_ALLOCATION == 8`, we would get:
+///
+/// power_of_two_size | order
+/// 8                 | 0
+/// 16                | 1
+/// 32                | 2
+/// 64                | 3
+/// ...
+/// 16777216          | 21
+/// 33554432          | 22
+///
+/// and so on.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+struct Order(u32);
+
+impl Order {
+	/// Create `Order` object from a raw order.
+	///
+	/// Returns `Err` if it is greater than the maximum supported order.
+	fn from_raw(order: u32) -> Result<Self, FreeBumpError> {
+		if order < N_ORDERS as u32 {
+			Ok(Self(order))
+		} else {
+			Err(error("invalid order"))
+		}
+	}
+
+	/// Compute the order by the given size
+	///
+	/// The size is clamped, so that the following holds:
+	///
+	/// `MIN_POSSIBLE_ALLOCATION <= size <= MAX_POSSIBLE_ALLOCATION`
+	fn from_size(size: u32) -> Result<Self, FreeBumpError> {
+		let clamped_size = if size > MAX_POSSIBLE_ALLOCATION {
+			log::warn!(target: LOG_TARGET, "going to fail due to allocating {:?}", size);
+			return Err(FreeBumpError::RequestedAllocationTooLarge)
+		} else if size < MIN_POSSIBLE_ALLOCATION {
+			MIN_POSSIBLE_ALLOCATION
+		} else {
+			size
+		};
+
+		// Round the clamped size to the next power of two.
+		//
+		// It returns the unchanged value if the value is already a power of two.
+		let power_of_two_size = clamped_size.next_power_of_two();
+
+		// Compute the number of trailing zeroes to get the order. We adjust it by the number of
+		// trailing zeroes in the minimum possible allocation.
+		let order = power_of_two_size.trailing_zeros() - MIN_POSSIBLE_ALLOCATION.trailing_zeros();
+
+		Ok(Self(order))
+	}
+
+	/// Returns the corresponding size in bytes for this order.
+	///
+	/// Note that it is always a power of two.
+	fn size(&self) -> u32 {
+		MIN_POSSIBLE_ALLOCATION << self.0
+	}
+
+	/// Extract the order as `u32`.
+	fn into_raw(self) -> u32 {
+		self.0
+	}
+}
+
+/// A special magic value for a pointer in a link that denotes the end of the linked list.
+const NIL_MARKER: u32 = u32::MAX;
+
+/// A link between headers in the free list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Link {
+	/// Nil, denotes that there is no next element.
+	Nil,
+	/// Link to the next element represented as a pointer to the a header.
+	Ptr(u32),
+}
+
+impl Link {
+	/// Creates a link from raw value.
+	fn from_raw(raw: u32) -> Self {
+		if raw != NIL_MARKER {
+			Self::Ptr(raw)
+		} else {
+			Self::Nil
+		}
+	}
+
+	/// Converts this link into a raw u32.
+	fn into_raw(self) -> u32 {
+		match self {
+			Self::Nil => NIL_MARKER,
+			Self::Ptr(ptr) => ptr,
+		}
+	}
+}
+
+/// A header of an allocation.
+///
+/// The header is encoded in memory as follows.
+///
+/// ## Free header
+///
+/// ```ignore
+/// 64             32                  0
+//  +--------------+-------------------+
+/// |            0 | next element link |
+/// +--------------+-------------------+
+/// ```
+/// ## Occupied header
+/// ```ignore
+/// 64             32                  0
+//  +--------------+-------------------+
+/// |            1 |             order |
+/// +--------------+-------------------+
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Header {
+	/// A free header contains a link to the next element to form a free linked list.
+	Free(Link),
+	/// An occupied header has attached order to know in which free list we should put the
+	/// allocation upon deallocation.
+	Occupied(Order),
+}
+
+impl Header {
+	/// Reads a header from memory.
+	///
+	/// Returns an error if the `header_ptr` is out of bounds of the linear memory or if the read
+	/// header is corrupted (e.g. the order is incorrect).
+	fn read_from<M: Memory + ?Sized>(memory: &M, header_ptr: u32) -> Result<Self, FreeBumpError> {
+		let raw_header = memory.read_le_u64(header_ptr)?;
+
+		// Check if the header represents an occupied or free allocation and extract the header data
+		// by trimming (and discarding) the high bits.
+		let occupied = raw_header & 0x00000001_00000000 != 0;
+		let header_data = raw_header as u32;
+
+		Ok(if occupied {
+			Self::Occupied(Order::from_raw(header_data)?)
+		} else {
+			Self::Free(Link::from_raw(header_data))
+		})
+	}
+
+	/// Write out this header to memory.
+	///
+	/// Returns an error if the `header_ptr` is out of bounds of the linear memory.
+	fn write_into<M: Memory + ?Sized>(&self, memory: &mut M, header_ptr: u32) -> Result<(), FreeBumpError> {
+		let (header_data, occupied_mask) = match *self {
+			Self::Occupied(order) => (order.into_raw(), 0x00000001_00000000),
+			Self::Free(link) => (link.into_raw(), 0x00000000_00000000),
+		};
+		let raw_header = header_data as u64 | occupied_mask;
+		memory.write_le_u64(header_ptr, raw_header)?;
+		Ok(())
+	}
+
+	/// Returns the order of the allocation if this is an occupied header.
+	fn into_occupied(self) -> Option<Order> {
+		match self {
+			Self::Occupied(order) => Some(order),
+			_ => None,
+		}
+	}
+
+	/// Returns the link to the next element in the free list if this is a free header.
+	fn into_free(self) -> Option<Link> {
+		match self {
+			Self::Free(link) => Some(link),
+			_ => None,
+		}
+	}
+}
+
+/// This struct represents a collection of intrusive linked lists for each order.
+struct FreeLists {
+	heads: [Link; N_ORDERS],
+}
+
+impl FreeLists {
+	/// Creates the free empty lists.
+	fn new() -> Self {
+		Self { heads: [Link::Nil; N_ORDERS] }
+	}
+
+	/// Replaces a given link for the specified order and returns the old one.
+	fn replace(&mut self, order: Order, new: Link) -> Link {
+		let prev = self[order];
+		self[order] = new;
+		prev
+	}
+}
+
+impl Index<Order> for FreeLists {
+	type Output = Link;
+	fn index(&self, index: Order) -> &Link {
+		&self.heads[index.0 as usize]
+	}
+}
+
+impl IndexMut<Order> for FreeLists {
+	fn index_mut(&mut self, index: Order) -> &mut Link {
+		&mut self.heads[index.0 as usize]
+	}
+}
+
+/// Memory allocation stats gathered during the lifetime of the allocator.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct AllocationStats {
+	/// The current number of bytes allocated.
+	///
+	/// This represents how many bytes are allocated *right now*.
+	pub bytes_allocated: u32,
+
+	/// The peak number of bytes ever allocated.
+	///
+	/// This is the maximum the `bytes_allocated` ever reached.
+	pub bytes_allocated_peak: u32,
+
+	/// The sum of every allocation ever made.
+	///
+	/// This increases every time a new allocation is made.
+	pub bytes_allocated_sum: u128,
+
+	/// The amount of address space (in bytes) used by the allocator.
+	///
+	/// This is calculated as the difference between the allocator's bumper
+	/// and the heap base.
+	///
+	/// Currently the bumper's only ever incremented, so this is simultaneously
+	/// the current value as well as the peak value.
+	pub address_space_used: u32,
+}
+
+/// Convert the given `size` in bytes into the number of pages.
+///
+/// The returned number of pages is ensured to be big enough to hold memory with the given `size`.
+///
+/// Returns `None` if the number of pages to not fit into `u32`.
+// fn pages_from_size(size: u64) -> Option<u32> {
+// 	u32::try_from((size + PAGE_SIZE as u64 - 1) / PAGE_SIZE as u64).ok()
+// }
+
+/// An implementation of freeing bump allocator.
+///
+/// Refer to the module-level documentation for further details.
+pub struct FreeingBumpHeapAllocator {
+	original_heap_base: u32,
+	bumper: u32,
+	free_lists: FreeLists,
+	poisoned: bool,
+	last_observed_memory_size: u32,
+	stats: AllocationStats,
+}
+
+impl Drop for FreeingBumpHeapAllocator {
+	fn drop(&mut self) {
+		log::debug!(target: LOG_TARGET, "allocator dropped: {:?}", self.stats)
+	}
+}
+
+impl FreeingBumpHeapAllocator {
+	/// Creates a new allocation heap which follows a freeing-bump strategy.
+	///
+	/// # Arguments
+	///
+	/// - `heap_base` - the offset from the beginning of the linear memory where the heap starts.
+	pub fn new(heap_base: u32) -> Self {
+		let aligned_heap_base = (heap_base + ALIGNMENT - 1) / ALIGNMENT * ALIGNMENT;
+
+		FreeingBumpHeapAllocator {
+			original_heap_base: aligned_heap_base,
+			bumper: aligned_heap_base,
+			free_lists: FreeLists::new(),
+			poisoned: false,
+			last_observed_memory_size: 0,
+			stats: AllocationStats::default(),
+		}
+	}
+
+	/// Gets requested number of bytes to allocate and returns a pointer.
+	/// The maximum size which can be allocated at once is 32 MiB.
+	/// There is no minimum size, but whatever size is passed into
+	/// this function is rounded to the next power of two. If the requested
+	/// size is below 8 bytes it will be rounded up to 8 bytes.
+	///
+	/// The identity or the type of the passed memory object does not matter. However, the size of
+	/// memory cannot shrink compared to the memory passed in previous invocations.
+	///
+	/// NOTE: Once the allocator has returned an error all subsequent requests will return an error.
+	///
+	/// # Arguments
+	///
+	/// - `mem` - a slice representing the linear memory on which this allocator operates.
+	/// - `size` - size in bytes of the allocation request
+	pub fn allocate<M: Memory + ?Sized> (
+		&mut self,
+		mem: &mut M,
+		size: WordSize,
+	) -> Result<Pointer<u8>, FreeBumpError> {
+		if self.poisoned {
+			return Err(error("the allocator has been poisoned"))
+		}
+
+		let bomb = PoisonBomb { poisoned: &mut self.poisoned };
+
+		Self::observe_memory_size(&mut self.last_observed_memory_size, mem)?;
+		let order = Order::from_size(size)?;
+
+		let header_ptr: u32 = match self.free_lists[order] {
+			Link::Ptr(header_ptr) => {
+				assert!(
+					header_ptr + order.size() + HEADER_SIZE <= mem.size(),
+					"Pointer is looked up in list of free entries, into which
+					only valid values are inserted; qed"
+				);
+
+				// Remove this header from the free list.
+				let next_free = Header::read_from(mem, header_ptr)?
+					.into_free()
+					.ok_or_else(|| error("free list points to a occupied header"))?;
+				self.free_lists[order] = next_free;
+
+				header_ptr
+			},
+			Link::Nil => {
+				// Corresponding free list is empty. Allocate a new item.
+				Self::bump(&mut self.bumper, order.size() + HEADER_SIZE, mem.size())?
+			},
+		};
+
+		// Write the order in the occupied header.
+		Header::Occupied(order).write_into(mem, header_ptr)?;
+
+		self.stats.bytes_allocated += order.size() + HEADER_SIZE;
+		self.stats.bytes_allocated_sum += u128::from(order.size() + HEADER_SIZE);
+		self.stats.bytes_allocated_peak =
+			max(self.stats.bytes_allocated_peak, self.stats.bytes_allocated);
+		self.stats.address_space_used = self.bumper - self.original_heap_base;
+
+		log::trace!(target: LOG_TARGET, "after allocation: {:?}", self.stats);
+
+		bomb.disarm();
+		Ok(Pointer::new(header_ptr + HEADER_SIZE))
+	}
+
+	/// Deallocates the space which was allocated for a pointer.
+	///
+	/// The identity or the type of the passed memory object does not matter. However, the size of
+	/// memory cannot shrink compared to the memory passed in previous invocations.
+	///
+	/// NOTE: Once the allocator has returned an error all subsequent requests will return an error.
+	///
+	/// # Arguments
+	///
+	/// - `mem` - a slice representing the linear memory on which this allocator operates.
+	/// - `ptr` - pointer to the allocated chunk
+	pub fn deallocate<M: Memory + ?Sized>(&mut self, mem: &mut M, ptr: Pointer<u8>) -> Result<(), FreeBumpError> {
+		if self.poisoned {
+			return Err(error("the allocator has been poisoned"))
+		}
+
+		let bomb = PoisonBomb { poisoned: &mut self.poisoned };
+
+		Self::observe_memory_size(&mut self.last_observed_memory_size, mem)?;
+
+		let header_ptr = u32::from(ptr)
+			.checked_sub(HEADER_SIZE)
+			.ok_or_else(|| error("Invalid pointer for deallocation"))?;
+
+		let order = Header::read_from(mem, header_ptr)?
+			.into_occupied()
+			.ok_or_else(|| error("the allocation points to an empty header"))?;
+
+		// Update the just freed header and knit it back to the free list.
+		let prev_head = self.free_lists.replace(order, Link::Ptr(header_ptr));
+		Header::Free(prev_head).write_into(mem, header_ptr)?;
+
+		self.stats.bytes_allocated = self
+			.stats
+			.bytes_allocated
+			.checked_sub(order.size() + HEADER_SIZE)
+			.ok_or_else(|| error("underflow of the currently allocated bytes count"))?;
+
+		log::trace!("after deallocation: {:?}", self.stats);
+
+		bomb.disarm();
+		Ok(())
+	}
+
+	/// Returns the allocation stats for this allocator.
+	pub fn stats(&self) -> AllocationStats {
+		self.stats.clone()
+	}
+
+	/// Increases the `bumper` by `size`.
+	///
+	/// Returns the `bumper` from before the increase. Returns an `Error::AllocatorOutOfSpace` if
+	/// the operation would exhaust the heap.
+	fn bump(bumper: &mut u32, size: u32, heap_end: u32) -> Result<u32, FreeBumpError> {
+		if *bumper + size > heap_end {
+			log::error!(
+				target: LOG_TARGET,
+				"running out of space with current bumper {}, mem size {}",
+				bumper,
+				heap_end
+			);
+			return Err(FreeBumpError::AllocatorOutOfSpace)
+		}
+
+		let res = *bumper;
+		*bumper += size;
+		Ok(res)
+	}
+
+	fn observe_memory_size<M: Memory + ?Sized> (
+		last_observed_memory_size: &mut u32,
+		mem: &mut M,
+	) -> Result<(), FreeBumpError> {
+		if mem.size() < *last_observed_memory_size {
+			return Err(FreeBumpError::MemoryShrinked)
+		}
+		*last_observed_memory_size = mem.size();
+		Ok(())
+	}
+}
+
+/// A trait for abstraction of accesses to a wasm linear memory. Used to read or modify the
+/// allocation prefixes.
+///
+/// A wasm linear memory behaves similarly to a vector. The address space doesn't have holes and is
+/// accessible up to the reported size.
+///
+/// The linear memory can grow in size with the wasm page granularity (64KiB), but it cannot shrink.
+pub trait Memory {
+	/// Read a u64 from the heap in LE form. Returns an error if any of the bytes read are out of
+	/// bounds.
+	fn read_le_u64(&self, ptr: u32) -> Result<u64, FreeBumpError>;
+	/// Write a u64 to the heap in LE form. Returns an error if any of the bytes written are out of
+	/// bounds.
+	fn write_le_u64(&mut self, ptr: u32, val: u64) -> Result<(), FreeBumpError>;
+	/// Returns the full size of the memory in bytes.
+	fn size(&self) -> u32;
+}
+
+impl Memory for [u8] {
+	fn read_le_u64(&self, ptr: u32) -> Result<u64, FreeBumpError> {
+		let range =
+			heap_range(ptr, 8, self.len()).ok_or_else(|| error("read out of heap bounds"))?;
+		let bytes = self[range]
+			.try_into()
+			.expect("[u8] slice of length 8 must be convertible to [u8; 8]");
+		Ok(u64::from_le_bytes(bytes))
+	}
+	fn write_le_u64(&mut self, ptr: u32, val: u64) -> Result<(), FreeBumpError> {
+		let range =
+			heap_range(ptr, 8, self.len()).ok_or_else(|| error("write out of heap bounds"))?;
+		let bytes = val.to_le_bytes();
+		self[range].copy_from_slice(&bytes[..]);
+		Ok(())
+	}
+	fn size(&self) -> u32 {
+		u32::try_from(self.len()).expect("size of Wasm linear memory is <2^32; qed")
+	}
+}
+
+fn heap_range(offset: u32, length: u32, heap_len: usize) -> Option<Range<usize>> {
+	let start = offset as usize;
+	let end = offset.checked_add(length)? as usize;
+	if end <= heap_len {
+		Some(start..end)
+	} else {
+		None
+	}
+}
+
+/// A guard that will raise the poisoned flag on drop unless disarmed.
+struct PoisonBomb<'a> {
+	poisoned: &'a mut bool,
+}
+
+impl<'a> PoisonBomb<'a> {
+	fn disarm(self) {
+		mem::forget(self)
+	}
+}
+
+impl<'a> Drop for PoisonBomb<'a> {
+	fn drop(&mut self) {
+		*self.poisoned = true;
+	}
+}

--- a/node/runtime-interfaces/src/lib.rs
+++ b/node/runtime-interfaces/src/lib.rs
@@ -1,0 +1,111 @@
+use sp_runtime_interface::runtime_interface;
+use sp_wasm_interface::{Pointer, Result as SandboxResult, Value, WordSize};
+pub type MemoryId = u32;
+use std::{cell::RefCell, rc::Rc, str, sync::Arc};
+mod sandbox_util;
+use crate::sandbox_util::Store;
+use sp_wasm_interface::Function;
+
+/// Something that provides access to the sandbox.
+#[runtime_interface]
+pub trait Sandbox {
+	/// Get sandbox memory from the `memory_id` instance at `offset` into the given buffer.
+	fn memory_get(
+		&mut self,
+		memory_idx: u32,
+		offset: u32,
+		buf_ptr: Pointer<u8>,
+		buf_len: u32,
+	) -> u32 {
+		// self.sandbox()
+		// 	.memory_get(memory_idx, offset, buf_ptr, buf_len)
+		// 	.expect("Failed to get memory with sandbox")
+		return 0;
+	}
+	/// Set sandbox memory from the given value.
+	fn memory_set(
+		&mut self,
+		memory_idx: u32,
+		offset: u32,
+		val_ptr: Pointer<u8>,
+		val_len: u32,
+	) -> u32 {
+		// self.sandbox()
+		// 	.memory_set(memory_idx, offset, val_ptr, val_len)
+		// 	.expect("Failed to set memory with sandbox")
+		return 0;
+	}
+	/// Delete a memory instance.
+	fn memory_teardown(&mut self, memory_idx: u32) {
+		// self.sandbox()
+		// 	.memory_teardown(memory_idx)
+		// 	.expect("Failed to teardown memory with sandbox")
+	}
+	/// Create a new memory instance with the given `initial` size and the `maximum` size.
+	/// The size is given in wasm pages.
+	fn memory_new(&mut self, initial: u32, maximum: u32) -> u32 {
+		// self.sandbox()
+		// 	.memory_new(initial, maximum)
+		// 	.expect("Failed to create new memory with sandbox")
+		return 0;
+	}
+	/// Invoke an exported function by a name.
+	fn invoke(
+		&mut self,
+		instance_idx: u32,
+		function: &str,
+		args: &[u8],
+		return_val_ptr: Pointer<u8>,
+		return_val_len: u32,
+		state_ptr: Pointer<u8>,
+	) -> u32 {
+		// self.sandbox()
+		// 	.invoke(instance_idx, function, args, return_val_ptr, return_val_len, state_ptr.into())
+		// 	.expect("Failed to invoke function with sandbox")
+		return 0;
+	}
+	/// Delete a sandbox instance.
+	fn instance_teardown(&mut self, instance_idx: u32) {
+		// self.sandbox()
+		// 	.instance_teardown(instance_idx)
+		// 	.expect("Failed to teardown sandbox instance")
+	}
+	// FixMe: didn't find this function in this file in the removal PR.
+	// /// Create a new sandbox instance.
+	// fn instance_new(
+	// 	&mut self,
+	// 	dispatch_thunk_id: u32,
+	// 	wasm: &[u8],
+	// 	raw_env_def: &[u8],
+	// 	state: u32,
+	// ) -> SandboxResult<u32> {
+	// 	return Ok(0);
+	// }
+	/// Get the value from a global with the given `name`. The sandbox is determined by the
+	/// given `instance_idx` instance.
+	///
+	/// Returns `Some(_)` when the requested global variable could be found.
+	fn get_global_val(
+		&mut self,
+		instance_idx: u32,
+		name: &str,
+	) -> Option<sp_wasm_interface::Value> {
+		// self.sandbox()
+		// 	.get_global_val(instance_idx, name)
+		// 	.expect("Failed to get global from sandbox")
+		return Some(Value::I32(0));
+	}
+}
+
+struct FunctionExecutor {
+	sandbox_store: Rc<RefCell<Store<wasmi::FuncRef>>>,
+	heap: RefCell<sc_allocator::FreeingBumpHeapAllocator>,
+	memory: MemoryRef,
+	table: Option<TableRef>,
+	host_functions: Arc<Vec<&'static dyn Function>>,
+	allow_missing_func_imports: bool,
+	missing_functions: Arc<Vec<String>>,
+	panic_message: Option<String>,
+}
+
+

--- a/node/runtime-interfaces/src/lib.rs
+++ b/node/runtime-interfaces/src/lib.rs
@@ -5,8 +5,11 @@ use std::{cell::RefCell, rc::Rc, str, sync::Arc};
 mod sandbox_util;
 mod env;
 mod util;
+mod wasmi_backend;
 use crate::sandbox_util::Store;
 use sp_wasm_interface::Function;
+use wasmi::TableRef;
+use wasmi::MemoryRef;
 
 /// Something that provides access to the sandbox.
 #[runtime_interface]

--- a/node/runtime-interfaces/src/lib.rs
+++ b/node/runtime-interfaces/src/lib.rs
@@ -3,6 +3,8 @@ use sp_wasm_interface::{Pointer, Result as SandboxResult, Value, WordSize};
 pub type MemoryId = u32;
 use std::{cell::RefCell, rc::Rc, str, sync::Arc};
 mod sandbox_util;
+mod env;
+mod util;
 use crate::sandbox_util::Store;
 use sp_wasm_interface::Function;
 

--- a/node/runtime-interfaces/src/lib.rs
+++ b/node/runtime-interfaces/src/lib.rs
@@ -25,10 +25,10 @@ pub trait Sandbox {
 		buf_ptr: Pointer<u8>,
 		buf_len: u32,
 	) -> u32 {
-		self.sandbox()
-			.memory_get(memory_idx, offset, buf_ptr, buf_len)
-			.expect("Failed to get memory with sandbox")
-		// return 0;
+		// self.sandbox()
+		// 	.memory_get(memory_idx, offset, buf_ptr, buf_len)
+		// 	.expect("Failed to get memory with sandbox")
+		return 0;
 	}
 	/// Set sandbox memory from the given value.
 	fn memory_set(

--- a/node/runtime-interfaces/src/sandbox_interface.rs
+++ b/node/runtime-interfaces/src/sandbox_interface.rs
@@ -1,0 +1,370 @@
+use std::{cell::RefCell, rc::Rc, str, sync::Arc, result};
+use sp_wasm_interface::{Function, FunctionContext, Pointer,  Result as WResult, Value, WordSize};
+use crate::FunctionExecutor;
+use crate::env as sandbox_env;
+use log::{debug, error, trace};
+use codec::{Decode, Encode};
+use crate::util::MemoryTransfer;
+use wasmi::RuntimeValue;
+use crate::sandbox_util as sandbox;
+use crate::wasmi_backend::trap;
+use sc_executor::error::{Error, Result};
+
+/// Sandbox memory identifier.
+pub type MemoryId = u32;
+
+// /// Result type used by traits in this crate.
+// #[cfg(feature = "std")]
+// pub type Result<T> = result::Result<T, String>;
+// #[cfg(not(feature = "std"))]
+// pub type Result<T> = result::Result<T, &'static str>;
+
+
+impl wasmi::Externals for FunctionExecutor {
+	fn invoke_index(
+		&mut self,
+		index: usize,
+		args: wasmi::RuntimeArgs,
+	) -> std::result::Result<Option<wasmi::RuntimeValue>, wasmi::Trap> {
+		let mut args = args.as_ref().iter().copied().map(|value| match value {
+			wasmi::RuntimeValue::I32(val) => Value::I32(val),
+			wasmi::RuntimeValue::I64(val) => Value::I64(val),
+			wasmi::RuntimeValue::F32(val) => Value::F32(val.into()),
+			wasmi::RuntimeValue::F64(val) => Value::F64(val.into()),
+		});
+
+		if let Some(function) = self.host_functions.clone().get(index) {
+			function
+				.execute(self, &mut args)
+				// .map_err(|msg| Error::FunctionExecution(function.name().to_string(), msg))
+				.map_err(|_msg| trap("Function call failed"))
+				.map_err(wasmi::Trap::from)
+				.map(|v| {
+					v.map(|value| match value {
+						Value::I32(val) => RuntimeValue::I32(val),
+						Value::I64(val) => RuntimeValue::I64(val),
+						Value::F32(val) => RuntimeValue::F32(val.into()),
+						Value::F64(val) => RuntimeValue::F64(val.into()),
+					})
+				})
+		} else if self.allow_missing_func_imports &&
+			index >= self.host_functions.len() &&
+			index < self.host_functions.len() + self.missing_functions.len()
+		{
+			Err(trap("Could not find host function with index"))
+		} else {
+			Err(trap("Could not find host function with index"))
+		}
+	}
+}
+
+struct SandboxContext<'a> {
+	executor: &'a mut FunctionExecutor,
+	dispatch_thunk: wasmi::FuncRef,
+}
+
+impl<'a> sandbox::SandboxContext for SandboxContext<'a> {
+	fn invoke(
+		&mut self,
+		invoke_args_ptr: Pointer<u8>,
+		invoke_args_len: WordSize,
+		state: u32,
+		func_idx: sandbox::SupervisorFuncIndex,
+	) -> Result<i64> {
+		let result = wasmi::FuncInstance::invoke(
+			&self.dispatch_thunk,
+			&[
+				RuntimeValue::I32(u32::from(invoke_args_ptr) as i32),
+				RuntimeValue::I32(invoke_args_len as i32),
+				RuntimeValue::I32(state as i32),
+				RuntimeValue::I32(usize::from(func_idx) as i32),
+			],
+			self.executor,
+		);
+
+		match result {
+			Ok(Some(RuntimeValue::I64(val))) => Ok(val),
+			Ok(_) => Err("Supervisor function returned unexpected result!".into()),
+			Err(err) => Err(Error::Other(err.to_string())),
+		}
+	}
+
+	fn supervisor_context(&mut self) -> &mut dyn FunctionContext {
+		self.executor
+	}
+}
+
+impl FunctionContext for FunctionExecutor {
+	fn read_memory_into(&self, address: Pointer<u8>, dest: &mut [u8]) -> WResult<()> {
+		self.memory.get_into(address.into(), dest).map_err(|e| e.to_string())
+	}
+
+	fn write_memory(&mut self, address: Pointer<u8>, data: &[u8]) -> WResult<()> {
+		self.memory.set(address.into(), data).map_err(|e| e.to_string())
+	}
+
+	fn allocate_memory(&mut self, size: WordSize) -> WResult<Pointer<u8>> {
+		let heap = &mut self.heap.borrow_mut();
+		self.memory
+			.with_direct_access_mut(|mem| heap.allocate(mem, size).map_err(|e| e.to_string()))
+	}
+
+	fn deallocate_memory(&mut self, ptr: Pointer<u8>) -> WResult<()> {
+		let heap = &mut self.heap.borrow_mut();
+		self.memory
+			.with_direct_access_mut(|mem| heap.deallocate(mem, ptr).map_err(|e| e.to_string()))
+	}
+
+	// fn sandbox(&mut self) -> &mut dyn Sandbox {
+	// 	self
+	// }
+
+	fn register_panic_error_message(&mut self, message: &str) {
+		self.panic_message = Some(message.to_owned());
+	}
+}
+
+/// Something that provides access to the sandbox.
+pub trait Sandbox {
+	/// Get sandbox memory from the `memory_id` instance at `offset` into the given buffer.
+	fn memory_get(
+		&mut self,
+		memory_id: MemoryId,
+		offset: WordSize,
+		buf_ptr: Pointer<u8>,
+		buf_len: WordSize,
+	) -> WResult<u32>;
+	/// Set sandbox memory from the given value.
+	fn memory_set(
+		&mut self,
+		memory_id: MemoryId,
+		offset: WordSize,
+		val_ptr: Pointer<u8>,
+		val_len: WordSize,
+	) -> WResult<u32>;
+	/// Delete a memory instance.
+	fn memory_teardown(&mut self, memory_id: MemoryId) -> WResult<()>;
+	/// Create a new memory instance with the given `initial` size and the `maximum` size.
+	/// The size is given in wasm pages.
+	fn memory_new(&mut self, initial: u32, maximum: u32) -> WResult<MemoryId>;
+	/// Invoke an exported function by a name.
+	fn invoke(
+		&mut self,
+		instance_id: u32,
+		export_name: &str,
+		args: &[u8],
+		return_val: Pointer<u8>,
+		return_val_len: WordSize,
+		state: u32,
+	) -> WResult<u32>;
+	/// Delete a sandbox instance.
+	fn instance_teardown(&mut self, instance_id: u32) -> WResult<()>;
+	/// Create a new sandbox instance.
+	// fn instance_new(
+	// 	&mut self,
+	// 	dispatch_thunk_id: u32,
+	// 	wasm: &[u8],
+	// 	raw_env_def: &[u8],
+	// 	state: u32,
+	// ) -> Result<u32>;
+
+	/// Get the value from a global with the given `name`. The sandbox is determined by the
+	/// given `instance_idx` instance.
+	///
+	/// Returns `Some(_)` when the requested global variable could be found.
+	fn get_global_val(&self, instance_idx: u32, name: &str) -> WResult<Option<Value>>;
+
+	/// Instantiate a new sandbox instance with the given `wasm_code`.
+	fn instantiate(
+		&mut self,
+		dispatch_thunk: u32,
+		wasm_code: &[u8],
+		env_def: &[u8],
+		state_ptr: Pointer<u8>,
+	) -> u32;
+}
+
+impl Sandbox for FunctionExecutor {
+	fn memory_get(
+		&mut self,
+		memory_id: MemoryId,
+		offset: WordSize,
+		buf_ptr: Pointer<u8>,
+		buf_len: WordSize,
+	) -> WResult<u32> {
+		let sandboxed_memory =
+			self.sandbox_store.borrow().memory(memory_id).map_err(|e| e.to_string())?;
+
+		let len = buf_len as usize;
+
+		let buffer = match sandboxed_memory.read(Pointer::new(offset as u32), len) {
+			Err(_) => return Ok(sandbox_env::ERR_OUT_OF_BOUNDS),
+			Ok(buffer) => buffer,
+		};
+
+		if self.memory.set(buf_ptr.into(), &buffer).is_err() {
+			return Ok(sandbox_env::ERR_OUT_OF_BOUNDS)
+		}
+
+		Ok(sandbox_env::ERR_OK)
+	}
+
+	fn memory_set(
+		&mut self,
+		memory_id: MemoryId,
+		offset: WordSize,
+		val_ptr: Pointer<u8>,
+		val_len: WordSize,
+	) -> WResult<u32> {
+		let sandboxed_memory =
+			self.sandbox_store.borrow().memory(memory_id).map_err(|e| e.to_string())?;
+
+		let len = val_len as usize;
+
+		#[allow(deprecated)]
+			let buffer = match self.memory.get(val_ptr.into(), len) {
+			Err(_) => return Ok(sandbox_env::ERR_OUT_OF_BOUNDS),
+			Ok(buffer) => buffer,
+		};
+
+		if sandboxed_memory.write_from(Pointer::new(offset as u32), &buffer).is_err() {
+			return Ok(sandbox_env::ERR_OUT_OF_BOUNDS)
+		}
+
+		Ok(sandbox_env::ERR_OK)
+	}
+
+	fn memory_teardown(&mut self, memory_id: MemoryId) -> WResult<()> {
+		self.sandbox_store
+			.borrow_mut()
+			.memory_teardown(memory_id)
+			.map_err(|e| e.to_string())
+	}
+
+	fn memory_new(&mut self, initial: u32, maximum: u32) -> WResult<MemoryId> {
+		self.sandbox_store
+			.borrow_mut()
+			.new_memory(initial, maximum)
+			.map_err(|e| e.to_string())
+	}
+
+	fn invoke(
+		&mut self,
+		instance_id: u32,
+		export_name: &str,
+		mut args: &[u8],
+		return_val: Pointer<u8>,
+		return_val_len: WordSize,
+		state: u32,
+	) -> WResult<u32> {
+		trace!(target: "sp-sandbox", "invoke, instance_idx={}", instance_id);
+
+		// Deserialize arguments and convert them into wasmi types.
+		let args = Vec::<sp_wasm_interface::Value>::decode(&mut args)
+			.map_err(|_| "Can't decode serialized arguments for the invocation")?
+			.into_iter()
+			.collect::<Vec<_>>();
+
+		let instance =
+			self.sandbox_store.borrow().instance(instance_id).map_err(|e| e.to_string())?;
+
+		let dispatch_thunk = self
+			.sandbox_store
+			.borrow()
+			.dispatch_thunk(instance_id)
+			.map_err(|e| e.to_string())?;
+
+		match instance.invoke(
+			export_name,
+			&args,
+			state,
+			&mut SandboxContext { dispatch_thunk, executor: self },
+		) {
+			Ok(None) => Ok(sandbox_env::ERR_OK),
+			Ok(Some(val)) => {
+				// Serialize return value and write it back into the memory.
+				sp_wasm_interface::ReturnValue::Value(val).using_encoded(|val| {
+					if val.len() > return_val_len as usize {
+						return Err("Return value buffer is too small".into())
+					}
+					self.write_memory(return_val, val).map_err(|_| "Return value buffer is OOB")?;
+					Ok(sandbox_env::ERR_OK)
+				})
+			},
+			Err(_) => Ok(sandbox_env::ERR_EXECUTION),
+		}
+	}
+
+	fn instance_teardown(&mut self, instance_id: u32) -> WResult<()> {
+		self.sandbox_store
+			.borrow_mut()
+			.instance_teardown(instance_id)
+			.map_err(|e| e.to_string())
+	}
+
+	// fn instance_new(
+	// 	&mut self,
+	// 	dispatch_thunk_id: u32,
+	// 	wasm: &[u8],
+	// 	raw_env_def: &[u8],
+	// 	state: u32,
+	// ) -> WResult<u32> {
+	// 	// Extract a dispatch thunk from instance's table by the specified index.
+	// 	let dispatch_thunk = {
+	// 		let table = self
+	// 			.table
+	// 			.as_ref()
+	// 			.ok_or("Runtime doesn't have a table; sandbox is unavailable")?;
+	// 		table
+	// 			.get(dispatch_thunk_id)
+	// 			.map_err(|_| "dispatch_thunk_idx is out of the table bounds")?
+	// 			.ok_or("dispatch_thunk_idx points on an empty table entry")?
+	// 	};
+	//
+	// 	let guest_env =
+	// 		match sandbox::GuestEnvironment::decode(&*self.sandbox_store.borrow(), raw_env_def) {
+	// 			Ok(guest_env) => guest_env,
+	// 			Err(_) => return Ok(sandbox_env::ERR_MODULE as u32),
+	// 		};
+	//
+	// 	let store = self.sandbox_store.clone();
+	// 	let result = store.borrow_mut().instantiate(
+	// 		wasm,
+	// 		guest_env,
+	// 		state,
+	// 		&mut SandboxContext { executor: self, dispatch_thunk: dispatch_thunk.clone() },
+	// 	);
+	//
+	// 	let instance_idx_or_err_code =
+	// 		match result.map(|i| i.register(&mut store.borrow_mut(), dispatch_thunk)) {
+	// 			Ok(instance_idx) => instance_idx,
+	// 			Err(sandbox::InstantiationError::StartTrapped) => sandbox_env::ERR_EXECUTION,
+	// 			Err(_) => sandbox_env::ERR_MODULE,
+	// 		};
+	//
+	// 	Ok(instance_idx_or_err_code)
+	// }
+
+	fn get_global_val(
+		&self,
+		instance_idx: u32,
+		name: &str,
+	) -> WResult<Option<sp_wasm_interface::Value>> {
+		self.sandbox_store
+			.borrow()
+			.instance(instance_idx)
+			.map(|i| i.get_global_val(name))
+			.map_err(|e| e.to_string())
+	}
+
+	/// Instantiate a new sandbox instance with the given `wasm_code`.
+	fn instantiate(
+		&mut self,
+		dispatch_thunk: u32,
+		wasm_code: &[u8],
+		env_def: &[u8],
+		state_ptr: Pointer<u8>,
+	) -> u32 {
+		return 0;
+	}
+}

--- a/node/runtime-interfaces/src/sandbox_util.rs
+++ b/node/runtime-interfaces/src/sandbox_util.rs
@@ -1,0 +1,585 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! This module implements sandboxing support in the runtime.
+//!
+//! Sandboxing is backed by wasmi and wasmer, depending on the configuration.
+
+#[cfg(feature = "wasmer-sandbox")]
+mod wasmer_backend;
+mod wasmi_backend;
+
+use std::{collections::HashMap, rc::Rc};
+
+use codec::Decode;
+use sp_sandbox::env as sandbox_env;
+use sp_wasm_interface::{FunctionContext, Pointer, WordSize};
+
+use crate::{
+	error::{self, Result},
+	util,
+};
+
+#[cfg(feature = "wasmer-sandbox")]
+use self::wasmer_backend::{
+	get_global as wasmer_get_global, instantiate as wasmer_instantiate, invoke as wasmer_invoke,
+	new_memory as wasmer_new_memory, Backend as WasmerBackend,
+	MemoryWrapper as WasmerMemoryWrapper,
+};
+use self::wasmi_backend::{
+	get_global as wasmi_get_global, instantiate as wasmi_instantiate, invoke as wasmi_invoke,
+	new_memory as wasmi_new_memory, MemoryWrapper as WasmiMemoryWrapper,
+};
+
+/// Index of a function inside the supervisor.
+///
+/// This is a typically an index in the default table of the supervisor, however
+/// the exact meaning of this index is depends on the implementation of dispatch function.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SupervisorFuncIndex(usize);
+
+impl From<SupervisorFuncIndex> for usize {
+	fn from(index: SupervisorFuncIndex) -> Self {
+		index.0
+	}
+}
+
+/// Index of a function within guest index space.
+///
+/// This index is supposed to be used as index for `Externals`.
+#[derive(Copy, Clone, Debug, PartialEq)]
+struct GuestFuncIndex(usize);
+
+/// This struct holds a mapping from guest index space to supervisor.
+struct GuestToSupervisorFunctionMapping {
+	/// Position of elements in this vector are interpreted
+	/// as indices of guest functions and are mapped to
+	/// corresponding supervisor function indices.
+	funcs: Vec<SupervisorFuncIndex>,
+}
+
+impl GuestToSupervisorFunctionMapping {
+	/// Create an empty function mapping
+	fn new() -> GuestToSupervisorFunctionMapping {
+		GuestToSupervisorFunctionMapping { funcs: Vec::new() }
+	}
+
+	/// Add a new supervisor function to the mapping.
+	/// Returns a newly assigned guest function index.
+	fn define(&mut self, supervisor_func: SupervisorFuncIndex) -> GuestFuncIndex {
+		let idx = self.funcs.len();
+		self.funcs.push(supervisor_func);
+		GuestFuncIndex(idx)
+	}
+
+	/// Find supervisor function index by its corresponding guest function index
+	fn func_by_guest_index(&self, guest_func_idx: GuestFuncIndex) -> Option<SupervisorFuncIndex> {
+		self.funcs.get(guest_func_idx.0).cloned()
+	}
+}
+
+/// Holds sandbox function and memory imports and performs name resolution
+struct Imports {
+	/// Maps qualified function name to its guest function index
+	func_map: HashMap<(Vec<u8>, Vec<u8>), GuestFuncIndex>,
+
+	/// Maps qualified field name to its memory reference
+	memories_map: HashMap<(Vec<u8>, Vec<u8>), Memory>,
+}
+
+impl Imports {
+	fn func_by_name(&self, module_name: &str, func_name: &str) -> Option<GuestFuncIndex> {
+		self.func_map
+			.get(&(module_name.as_bytes().to_owned(), func_name.as_bytes().to_owned()))
+			.cloned()
+	}
+
+	fn memory_by_name(&self, module_name: &str, memory_name: &str) -> Option<Memory> {
+		self.memories_map
+			.get(&(module_name.as_bytes().to_owned(), memory_name.as_bytes().to_owned()))
+			.cloned()
+	}
+}
+
+/// The sandbox context used to execute sandboxed functions.
+pub trait SandboxContext {
+	/// Invoke a function in the supervisor environment.
+	///
+	/// This first invokes the dispatch thunk function, passing in the function index of the
+	/// desired function to call and serialized arguments. The thunk calls the desired function
+	/// with the deserialized arguments, then serializes the result into memory and returns
+	/// reference. The pointer to and length of the result in linear memory is encoded into an
+	/// `i64`, with the upper 32 bits representing the pointer and the lower 32 bits representing
+	/// the length.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if the dispatch_thunk function has an incorrect signature or traps during
+	/// execution.
+	fn invoke(
+		&mut self,
+		invoke_args_ptr: Pointer<u8>,
+		invoke_args_len: WordSize,
+		state: u32,
+		func_idx: SupervisorFuncIndex,
+	) -> Result<i64>;
+
+	/// Returns the supervisor context.
+	fn supervisor_context(&mut self) -> &mut dyn FunctionContext;
+}
+
+/// Implementation of [`Externals`] that allows execution of guest module with
+/// [externals][`Externals`] that might refer functions defined by supervisor.
+///
+/// [`Externals`]: ../wasmi/trait.Externals.html
+pub struct GuestExternals<'a> {
+	/// Instance of sandboxed module to be dispatched
+	sandbox_instance: &'a SandboxInstance,
+
+	/// External state passed to guest environment, see the `instantiate` function
+	state: u32,
+}
+
+/// Module instance in terms of selected backend
+enum BackendInstance {
+	/// Wasmi module instance
+	Wasmi(wasmi::ModuleRef),
+
+	/// Wasmer module instance
+	#[cfg(feature = "wasmer-sandbox")]
+	Wasmer(wasmer::Instance),
+}
+
+/// Sandboxed instance of a wasm module.
+///
+/// It's primary purpose is to [`invoke`] exported functions on it.
+///
+/// All imports of this instance are specified at the creation time and
+/// imports are implemented by the supervisor.
+///
+/// Hence, in order to invoke an exported function on a sandboxed module instance,
+/// it's required to provide supervisor externals: it will be used to execute
+/// code in the supervisor context.
+///
+/// This is generic over a supervisor function reference type.
+///
+/// [`invoke`]: #method.invoke
+pub struct SandboxInstance {
+	backend_instance: BackendInstance,
+	guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
+}
+
+impl SandboxInstance {
+	/// Invoke an exported function by a name.
+	///
+	/// `supervisor_externals` is required to execute the implementations
+	/// of the syscalls that published to a sandboxed module instance.
+	///
+	/// The `state` parameter can be used to provide custom data for
+	/// these syscall implementations.
+	pub fn invoke(
+		&self,
+		export_name: &str,
+		args: &[sp_wasm_interface::Value],
+		state: u32,
+		sandbox_context: &mut dyn SandboxContext,
+	) -> std::result::Result<Option<sp_wasm_interface::Value>, error::Error> {
+		match &self.backend_instance {
+			BackendInstance::Wasmi(wasmi_instance) =>
+				wasmi_invoke(self, wasmi_instance, export_name, args, state, sandbox_context),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			BackendInstance::Wasmer(wasmer_instance) =>
+				wasmer_invoke(wasmer_instance, export_name, args, state, sandbox_context),
+		}
+	}
+
+	/// Get the value from a global with the given `name`.
+	///
+	/// Returns `Some(_)` if the global could be found.
+	pub fn get_global_val(&self, name: &str) -> Option<sp_wasm_interface::Value> {
+		match &self.backend_instance {
+			BackendInstance::Wasmi(wasmi_instance) => wasmi_get_global(wasmi_instance, name),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			BackendInstance::Wasmer(wasmer_instance) => wasmer_get_global(wasmer_instance, name),
+		}
+	}
+}
+
+/// Error occurred during instantiation of a sandboxed module.
+pub enum InstantiationError {
+	/// Something wrong with the environment definition. It either can't
+	/// be decoded, have a reference to a non-existent or torn down memory instance.
+	EnvironmentDefinitionCorrupted,
+	/// Provided module isn't recognized as a valid webassembly binary.
+	ModuleDecoding,
+	/// Module is a well-formed webassembly binary but could not be instantiated. This could
+	/// happen because, e.g. the module imports entries not provided by the environment.
+	Instantiation,
+	/// Module is well-formed, instantiated and linked, but while executing the start function
+	/// a trap was generated.
+	StartTrapped,
+	/// The code was compiled with a CPU feature not available on the host.
+	CpuFeature,
+}
+
+fn decode_environment_definition(
+	mut raw_env_def: &[u8],
+	memories: &[Option<Memory>],
+) -> std::result::Result<(Imports, GuestToSupervisorFunctionMapping), InstantiationError> {
+	let env_def = sandbox_env::EnvironmentDefinition::decode(&mut raw_env_def)
+		.map_err(|_| InstantiationError::EnvironmentDefinitionCorrupted)?;
+
+	let mut func_map = HashMap::new();
+	let mut memories_map = HashMap::new();
+	let mut guest_to_supervisor_mapping = GuestToSupervisorFunctionMapping::new();
+
+	for entry in &env_def.entries {
+		let module = entry.module_name.clone();
+		let field = entry.field_name.clone();
+
+		match entry.entity {
+			sandbox_env::ExternEntity::Function(func_idx) => {
+				let externals_idx =
+					guest_to_supervisor_mapping.define(SupervisorFuncIndex(func_idx as usize));
+				func_map.insert((module, field), externals_idx);
+			},
+			sandbox_env::ExternEntity::Memory(memory_idx) => {
+				let memory_ref = memories
+					.get(memory_idx as usize)
+					.cloned()
+					.ok_or(InstantiationError::EnvironmentDefinitionCorrupted)?
+					.ok_or(InstantiationError::EnvironmentDefinitionCorrupted)?;
+				memories_map.insert((module, field), memory_ref);
+			},
+		}
+	}
+
+	Ok((Imports { func_map, memories_map }, guest_to_supervisor_mapping))
+}
+
+/// An environment in which the guest module is instantiated.
+pub struct GuestEnvironment {
+	/// Function and memory imports of the guest module
+	imports: Imports,
+
+	/// Supervisor functinons mapped to guest index space
+	guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
+}
+
+impl GuestEnvironment {
+	/// Decodes an environment definition from the given raw bytes.
+	///
+	/// Returns `Err` if the definition cannot be decoded.
+	pub fn decode<DT>(
+		store: &Store<DT>,
+		raw_env_def: &[u8],
+	) -> std::result::Result<Self, InstantiationError> {
+		let (imports, guest_to_supervisor_mapping) =
+			decode_environment_definition(raw_env_def, &store.memories)?;
+		Ok(Self { imports, guest_to_supervisor_mapping })
+	}
+}
+
+/// An unregistered sandboxed instance.
+///
+/// To finish off the instantiation the user must call `register`.
+#[must_use]
+pub struct UnregisteredInstance {
+	sandbox_instance: Rc<SandboxInstance>,
+}
+
+impl UnregisteredInstance {
+	/// Finalizes instantiation of this module.
+	pub fn register<DT>(self, store: &mut Store<DT>, dispatch_thunk: DT) -> u32 {
+		// At last, register the instance.
+		store.register_sandbox_instance(self.sandbox_instance, dispatch_thunk)
+	}
+}
+
+/// Sandbox backend to use
+pub enum SandboxBackend {
+	/// Wasm interpreter
+	Wasmi,
+
+	/// Wasmer environment
+	#[cfg(feature = "wasmer-sandbox")]
+	Wasmer,
+
+	/// Use wasmer backend if available. Fall back to wasmi otherwise.
+	TryWasmer,
+}
+
+/// Memory reference in terms of a selected backend
+#[derive(Clone, Debug)]
+pub enum Memory {
+	/// Wasmi memory reference
+	Wasmi(WasmiMemoryWrapper),
+
+	/// Wasmer memory refernce
+	#[cfg(feature = "wasmer-sandbox")]
+	Wasmer(WasmerMemoryWrapper),
+}
+
+impl Memory {
+	/// View as wasmi memory
+	pub fn as_wasmi(&self) -> Option<WasmiMemoryWrapper> {
+		match self {
+			Memory::Wasmi(memory) => Some(memory.clone()),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(_) => None,
+		}
+	}
+
+	/// View as wasmer memory
+	#[cfg(feature = "wasmer-sandbox")]
+	pub fn as_wasmer(&self) -> Option<WasmerMemoryWrapper> {
+		match self {
+			Memory::Wasmer(memory) => Some(memory.clone()),
+			Memory::Wasmi(_) => None,
+		}
+	}
+}
+
+impl util::MemoryTransfer for Memory {
+	fn read(&self, source_addr: Pointer<u8>, size: usize) -> Result<Vec<u8>> {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.read(source_addr, size),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.read(source_addr, size),
+		}
+	}
+
+	fn read_into(&self, source_addr: Pointer<u8>, destination: &mut [u8]) -> Result<()> {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.read_into(source_addr, destination),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.read_into(source_addr, destination),
+		}
+	}
+
+	fn write_from(&self, dest_addr: Pointer<u8>, source: &[u8]) -> Result<()> {
+		match self {
+			Memory::Wasmi(sandboxed_memory) => sandboxed_memory.write_from(dest_addr, source),
+
+			#[cfg(feature = "wasmer-sandbox")]
+			Memory::Wasmer(sandboxed_memory) => sandboxed_memory.write_from(dest_addr, source),
+		}
+	}
+}
+
+/// Information specific to a particular execution backend
+enum BackendContext {
+	/// Wasmi specific context
+	Wasmi,
+
+	/// Wasmer specific context
+	#[cfg(feature = "wasmer-sandbox")]
+	Wasmer(WasmerBackend),
+}
+
+impl BackendContext {
+	pub fn new(backend: SandboxBackend) -> BackendContext {
+		match backend {
+			SandboxBackend::Wasmi => BackendContext::Wasmi,
+
+			#[cfg(not(feature = "wasmer-sandbox"))]
+			SandboxBackend::TryWasmer => BackendContext::Wasmi,
+
+			#[cfg(feature = "wasmer-sandbox")]
+			SandboxBackend::Wasmer | SandboxBackend::TryWasmer =>
+				BackendContext::Wasmer(WasmerBackend::new()),
+		}
+	}
+}
+
+/// This struct keeps track of all sandboxed components.
+///
+/// This is generic over a supervisor function reference type.
+pub struct Store<DT> {
+	/// Stores the instance and the dispatch thunk associated to per instance.
+	///
+	/// Instances are `Some` until torn down.
+	instances: Vec<Option<(Rc<SandboxInstance>, DT)>>,
+	/// Memories are `Some` until torn down.
+	memories: Vec<Option<Memory>>,
+	backend_context: BackendContext,
+}
+
+impl<DT: Clone> Store<DT> {
+	/// Create a new empty sandbox store.
+	pub fn new(backend: SandboxBackend) -> Self {
+		Store {
+			instances: Vec::new(),
+			memories: Vec::new(),
+			backend_context: BackendContext::new(backend),
+		}
+	}
+
+	/// Create a new memory instance and return it's index.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if the memory couldn't be created.
+	/// Typically happens if `initial` is more than `maximum`.
+	pub fn new_memory(&mut self, initial: u32, maximum: u32) -> Result<u32> {
+		let memories = &mut self.memories;
+		let backend_context = &self.backend_context;
+
+		let maximum = match maximum {
+			sandbox_env::MEM_UNLIMITED => None,
+			specified_limit => Some(specified_limit),
+		};
+
+		let memory = match &backend_context {
+			BackendContext::Wasmi => wasmi_new_memory(initial, maximum)?,
+
+			#[cfg(feature = "wasmer-sandbox")]
+			BackendContext::Wasmer(context) => wasmer_new_memory(context, initial, maximum)?,
+		};
+
+		let mem_idx = memories.len();
+		memories.push(Some(memory));
+
+		Ok(mem_idx as u32)
+	}
+
+	/// Returns `SandboxInstance` by `instance_idx`.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` If `instance_idx` isn't a valid index of an instance or
+	/// instance is already torndown.
+	pub fn instance(&self, instance_idx: u32) -> Result<Rc<SandboxInstance>> {
+		self.instances
+			.get(instance_idx as usize)
+			.ok_or("Trying to access a non-existent instance")?
+			.as_ref()
+			.map(|v| v.0.clone())
+			.ok_or_else(|| "Trying to access a torndown instance".into())
+	}
+
+	/// Returns dispatch thunk by `instance_idx`.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` If `instance_idx` isn't a valid index of an instance or
+	/// instance is already torndown.
+	pub fn dispatch_thunk(&self, instance_idx: u32) -> Result<DT> {
+		self.instances
+			.get(instance_idx as usize)
+			.as_ref()
+			.ok_or("Trying to access a non-existent instance")?
+			.as_ref()
+			.map(|v| v.1.clone())
+			.ok_or_else(|| "Trying to access a torndown instance".into())
+	}
+
+	/// Returns reference to a memory instance by `memory_idx`.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` If `memory_idx` isn't a valid index of an memory or
+	/// if memory has been torn down.
+	pub fn memory(&self, memory_idx: u32) -> Result<Memory> {
+		self.memories
+			.get(memory_idx as usize)
+			.cloned()
+			.ok_or("Trying to access a non-existent sandboxed memory")?
+			.ok_or_else(|| "Trying to access a torndown sandboxed memory".into())
+	}
+
+	/// Tear down the memory at the specified index.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if `memory_idx` isn't a valid index of an memory or
+	/// if it has been torn down.
+	pub fn memory_teardown(&mut self, memory_idx: u32) -> Result<()> {
+		match self.memories.get_mut(memory_idx as usize) {
+			None => Err("Trying to teardown a non-existent sandboxed memory".into()),
+			Some(None) => Err("Double teardown of a sandboxed memory".into()),
+			Some(memory) => {
+				*memory = None;
+				Ok(())
+			},
+		}
+	}
+
+	/// Tear down the instance at the specified index.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if `instance_idx` isn't a valid index of an instance or
+	/// if it has been torn down.
+	pub fn instance_teardown(&mut self, instance_idx: u32) -> Result<()> {
+		match self.instances.get_mut(instance_idx as usize) {
+			None => Err("Trying to teardown a non-existent instance".into()),
+			Some(None) => Err("Double teardown of an instance".into()),
+			Some(instance) => {
+				*instance = None;
+				Ok(())
+			},
+		}
+	}
+
+	/// Instantiate a guest module and return it's index in the store.
+	///
+	/// The guest module's code is specified in `wasm`. Environment that will be available to
+	/// guest module is specified in `guest_env`. A dispatch thunk is used as function that
+	/// handle calls from guests. `state` is an opaque pointer to caller's arbitrary context
+	/// normally created by `sp_sandbox::Instance` primitive.
+	///
+	/// Note: Due to borrowing constraints dispatch thunk is now propagated using DTH
+	///
+	/// Returns uninitialized sandboxed module instance or an instantiation error.
+	pub fn instantiate(
+		&mut self,
+		wasm: &[u8],
+		guest_env: GuestEnvironment,
+		state: u32,
+		sandbox_context: &mut dyn SandboxContext,
+	) -> std::result::Result<UnregisteredInstance, InstantiationError> {
+		let sandbox_instance = match self.backend_context {
+			BackendContext::Wasmi => wasmi_instantiate(wasm, guest_env, state, sandbox_context)?,
+
+			#[cfg(feature = "wasmer-sandbox")]
+			BackendContext::Wasmer(ref context) =>
+				wasmer_instantiate(context, wasm, guest_env, state, sandbox_context)?,
+		};
+
+		Ok(UnregisteredInstance { sandbox_instance })
+	}
+}
+
+// Private routines
+impl<DT> Store<DT> {
+	fn register_sandbox_instance(
+		&mut self,
+		sandbox_instance: Rc<SandboxInstance>,
+		dispatch_thunk: DT,
+	) -> u32 {
+		let instance_idx = self.instances.len();
+		self.instances.push(Some((sandbox_instance, dispatch_thunk)));
+		instance_idx as u32
+	}
+}

--- a/node/runtime-interfaces/src/sandbox_util.rs
+++ b/node/runtime-interfaces/src/sandbox_util.rs
@@ -27,13 +27,14 @@ mod wasmi_backend;
 use std::{collections::HashMap, rc::Rc};
 
 use codec::Decode;
-use sp_sandbox::env as sandbox_env;
+use crate::env as sandbox_env;
 use sp_wasm_interface::{FunctionContext, Pointer, WordSize};
 
 use crate::{
-	error::{self, Result},
 	util,
 };
+use sc_executor::error::{Error, Result};
+
 
 #[cfg(feature = "wasmer-sandbox")]
 use self::wasmer_backend::{
@@ -198,7 +199,7 @@ impl SandboxInstance {
 		args: &[sp_wasm_interface::Value],
 		state: u32,
 		sandbox_context: &mut dyn SandboxContext,
-	) -> std::result::Result<Option<sp_wasm_interface::Value>, error::Error> {
+	) -> std::result::Result<Option<sp_wasm_interface::Value>, Error> {
 		match &self.backend_instance {
 			BackendInstance::Wasmi(wasmi_instance) =>
 				wasmi_invoke(self, wasmi_instance, export_name, args, state, sandbox_context),

--- a/node/runtime-interfaces/src/sandbox_util.rs
+++ b/node/runtime-interfaces/src/sandbox_util.rs
@@ -22,7 +22,6 @@
 
 #[cfg(feature = "wasmer-sandbox")]
 mod wasmer_backend;
-mod wasmi_backend;
 
 use std::{collections::HashMap, rc::Rc};
 
@@ -31,7 +30,7 @@ use crate::env as sandbox_env;
 use sp_wasm_interface::{FunctionContext, Pointer, WordSize};
 
 use crate::{
-	util,
+	util,wasmi_backend,
 };
 use sc_executor::error::{Error, Result};
 
@@ -64,10 +63,10 @@ impl From<SupervisorFuncIndex> for usize {
 ///
 /// This index is supposed to be used as index for `Externals`.
 #[derive(Copy, Clone, Debug, PartialEq)]
-struct GuestFuncIndex(usize);
+pub struct GuestFuncIndex(pub usize);
 
 /// This struct holds a mapping from guest index space to supervisor.
-struct GuestToSupervisorFunctionMapping {
+pub struct GuestToSupervisorFunctionMapping {
 	/// Position of elements in this vector are interpreted
 	/// as indices of guest functions and are mapped to
 	/// corresponding supervisor function indices.
@@ -89,13 +88,13 @@ impl GuestToSupervisorFunctionMapping {
 	}
 
 	/// Find supervisor function index by its corresponding guest function index
-	fn func_by_guest_index(&self, guest_func_idx: GuestFuncIndex) -> Option<SupervisorFuncIndex> {
+	pub fn func_by_guest_index(&self, guest_func_idx: GuestFuncIndex) -> Option<SupervisorFuncIndex> {
 		self.funcs.get(guest_func_idx.0).cloned()
 	}
 }
 
 /// Holds sandbox function and memory imports and performs name resolution
-struct Imports {
+pub struct Imports {
 	/// Maps qualified function name to its guest function index
 	func_map: HashMap<(Vec<u8>, Vec<u8>), GuestFuncIndex>,
 
@@ -104,13 +103,13 @@ struct Imports {
 }
 
 impl Imports {
-	fn func_by_name(&self, module_name: &str, func_name: &str) -> Option<GuestFuncIndex> {
+	pub fn func_by_name(&self, module_name: &str, func_name: &str) -> Option<GuestFuncIndex> {
 		self.func_map
 			.get(&(module_name.as_bytes().to_owned(), func_name.as_bytes().to_owned()))
 			.cloned()
 	}
 
-	fn memory_by_name(&self, module_name: &str, memory_name: &str) -> Option<Memory> {
+	pub fn memory_by_name(&self, module_name: &str, memory_name: &str) -> Option<Memory> {
 		self.memories_map
 			.get(&(module_name.as_bytes().to_owned(), memory_name.as_bytes().to_owned()))
 			.cloned()
@@ -150,14 +149,14 @@ pub trait SandboxContext {
 /// [`Externals`]: ../wasmi/trait.Externals.html
 pub struct GuestExternals<'a> {
 	/// Instance of sandboxed module to be dispatched
-	sandbox_instance: &'a SandboxInstance,
+	pub sandbox_instance: &'a SandboxInstance,
 
 	/// External state passed to guest environment, see the `instantiate` function
-	state: u32,
+	pub state: u32,
 }
 
 /// Module instance in terms of selected backend
-enum BackendInstance {
+pub enum BackendInstance {
 	/// Wasmi module instance
 	Wasmi(wasmi::ModuleRef),
 
@@ -181,8 +180,8 @@ enum BackendInstance {
 ///
 /// [`invoke`]: #method.invoke
 pub struct SandboxInstance {
-	backend_instance: BackendInstance,
-	guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
+	pub backend_instance: BackendInstance,
+	pub guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
 }
 
 impl SandboxInstance {
@@ -278,10 +277,10 @@ fn decode_environment_definition(
 /// An environment in which the guest module is instantiated.
 pub struct GuestEnvironment {
 	/// Function and memory imports of the guest module
-	imports: Imports,
+	pub imports: Imports,
 
 	/// Supervisor functinons mapped to guest index space
-	guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
+	pub guest_to_supervisor_mapping: GuestToSupervisorFunctionMapping,
 }
 
 impl GuestEnvironment {

--- a/node/runtime-interfaces/src/util.rs
+++ b/node/runtime-interfaces/src/util.rs
@@ -1,0 +1,52 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Utilities used by all backends
+use sc_executor::error::{Result};
+
+use sp_wasm_interface::Pointer;
+use std::ops::Range;
+
+/// Construct a range from an offset to a data length after the offset.
+/// Returns None if the end of the range would exceed some maximum offset.
+pub fn checked_range(offset: usize, len: usize, max: usize) -> Option<Range<usize>> {
+	let end = offset.checked_add(len)?;
+	if end <= max {
+		Some(offset..end)
+	} else {
+		None
+	}
+}
+
+/// Provides safe memory access interface using an external buffer
+pub trait MemoryTransfer {
+	/// Read data from a slice of memory into a newly allocated buffer.
+	///
+	/// Returns an error if the read would go out of the memory bounds.
+	fn read(&self, source_addr: Pointer<u8>, size: usize) -> Result<Vec<u8>>;
+
+	/// Read data from a slice of memory into a destination buffer.
+	///
+	/// Returns an error if the read would go out of the memory bounds.
+	fn read_into(&self, source_addr: Pointer<u8>, destination: &mut [u8]) -> Result<()>;
+
+	/// Write data to a slice of memory.
+	///
+	/// Returns an error if the write would go out of the memory bounds.
+	fn write_from(&self, dest_addr: Pointer<u8>, source: &[u8]) -> Result<()>;
+}

--- a/node/runtime-interfaces/src/wasmi_backend.rs
+++ b/node/runtime-interfaces/src/wasmi_backend.rs
@@ -1,0 +1,369 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Wasmi specific impls for sandbox
+
+use std::{fmt, rc::Rc};
+
+use codec::{Decode, Encode};
+use sp_wasm_interface::{FunctionContext, Pointer, ReturnValue, Value, WordSize};
+use wasmi::{
+	memory_units::Pages, ImportResolver, MemoryInstance, Module, ModuleInstance, RuntimeArgs,
+	RuntimeValue, Trap,
+};
+
+use sc_executor::error::{Error, Result};
+use crate::{
+	sandbox_util::{
+		BackendInstance, GuestEnvironment, GuestExternals, GuestFuncIndex, Imports,
+		InstantiationError, Memory, SandboxContext, SandboxInstance,
+	},
+	util::{checked_range, MemoryTransfer},
+	env::HostError,
+};
+
+environmental::environmental!(SandboxContextStore: trait SandboxContext);
+
+#[derive(Debug)]
+struct CustomHostError(String);
+
+impl fmt::Display for CustomHostError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "HostError: {}", self.0)
+	}
+}
+
+impl wasmi::HostError for CustomHostError {}
+
+/// Construct trap error from specified message
+pub fn trap(msg: &'static str) -> Trap {
+	Trap::host(CustomHostError(msg.into()))
+}
+
+impl ImportResolver for Imports {
+	fn resolve_func(
+		&self,
+		module_name: &str,
+		field_name: &str,
+		signature: &wasmi::Signature,
+	) -> std::result::Result<wasmi::FuncRef, wasmi::Error> {
+		let idx = self.func_by_name(module_name, field_name).ok_or_else(|| {
+			wasmi::Error::Instantiation(format!("Export {}:{} not found", module_name, field_name))
+		})?;
+
+		Ok(wasmi::FuncInstance::alloc_host(signature.clone(), idx.0))
+	}
+
+	fn resolve_memory(
+		&self,
+		module_name: &str,
+		field_name: &str,
+		_memory_type: &wasmi::MemoryDescriptor,
+	) -> std::result::Result<wasmi::MemoryRef, wasmi::Error> {
+		let mem = self.memory_by_name(module_name, field_name).ok_or_else(|| {
+			wasmi::Error::Instantiation(format!("Export {}:{} not found", module_name, field_name))
+		})?;
+
+		let wrapper = mem.as_wasmi().ok_or_else(|| {
+			wasmi::Error::Instantiation(format!(
+				"Unsupported non-wasmi export {}:{}",
+				module_name, field_name
+			))
+		})?;
+
+		// Here we use inner memory reference only to resolve the imports
+		// without accessing the memory contents. All subsequent memory accesses
+		// should happen through the wrapper, that enforces the memory access protocol.
+		let mem = wrapper.0;
+
+		Ok(mem)
+	}
+
+	fn resolve_global(
+		&self,
+		module_name: &str,
+		field_name: &str,
+		_global_type: &wasmi::GlobalDescriptor,
+	) -> std::result::Result<wasmi::GlobalRef, wasmi::Error> {
+		Err(wasmi::Error::Instantiation(format!("Export {}:{} not found", module_name, field_name)))
+	}
+
+	fn resolve_table(
+		&self,
+		module_name: &str,
+		field_name: &str,
+		_table_type: &wasmi::TableDescriptor,
+	) -> std::result::Result<wasmi::TableRef, wasmi::Error> {
+		Err(wasmi::Error::Instantiation(format!("Export {}:{} not found", module_name, field_name)))
+	}
+}
+
+/// Allocate new memory region
+pub fn new_memory(initial: u32, maximum: Option<u32>) -> Result<Memory> {
+	let memory = Memory::Wasmi(MemoryWrapper::new(
+		MemoryInstance::alloc(Pages(initial as usize), maximum.map(|m| Pages(m as usize)))
+			.map_err(|error| Error::Other(error.to_string()))?,
+	));
+
+	Ok(memory)
+}
+
+/// Wasmi provides direct access to its memory using slices.
+///
+/// This wrapper limits the scope where the slice can be taken to
+#[derive(Debug, Clone)]
+pub struct MemoryWrapper(wasmi::MemoryRef);
+
+impl MemoryWrapper {
+	/// Take ownership of the memory region and return a wrapper object
+	fn new(memory: wasmi::MemoryRef) -> Self {
+		Self(memory)
+	}
+}
+
+impl MemoryTransfer for MemoryWrapper {
+	fn read(&self, source_addr: Pointer<u8>, size: usize) -> Result<Vec<u8>> {
+		self.0.with_direct_access(|source| {
+			let range = checked_range(source_addr.into(), size, source.len())
+				.ok_or_else(|| Error::Other("memory read is out of bounds".into()))?;
+
+			Ok(Vec::from(&source[range]))
+		})
+	}
+
+	fn read_into(&self, source_addr: Pointer<u8>, destination: &mut [u8]) -> Result<()> {
+		self.0.with_direct_access(|source| {
+			let range = checked_range(source_addr.into(), destination.len(), source.len())
+				.ok_or_else(|| Error::Other("memory read is out of bounds".into()))?;
+
+			destination.copy_from_slice(&source[range]);
+			Ok(())
+		})
+	}
+
+	fn write_from(&self, dest_addr: Pointer<u8>, source: &[u8]) -> Result<()> {
+		self.0.with_direct_access_mut(|destination| {
+			let range = checked_range(dest_addr.into(), source.len(), destination.len())
+				.ok_or_else(|| Error::Other("memory write is out of bounds".into()))?;
+
+			destination[range].copy_from_slice(source);
+			Ok(())
+		})
+	}
+}
+
+impl<'a> wasmi::Externals for GuestExternals<'a> {
+	fn invoke_index(
+		&mut self,
+		index: usize,
+		args: RuntimeArgs,
+	) -> std::result::Result<Option<RuntimeValue>, Trap> {
+		SandboxContextStore::with(|sandbox_context| {
+			// Make `index` typesafe again.
+			let index = GuestFuncIndex(index);
+
+			// Convert function index from guest to supervisor space
+			let func_idx = self.sandbox_instance
+				.guest_to_supervisor_mapping
+				.func_by_guest_index(index)
+				.expect(
+					"`invoke_index` is called with indexes registered via `FuncInstance::alloc_host`;
+					`FuncInstance::alloc_host` is called with indexes that were obtained from `guest_to_supervisor_mapping`;
+					`func_by_guest_index` called with `index` can't return `None`;
+					qed"
+				);
+
+			// Serialize arguments into a byte vector.
+			let invoke_args_data: Vec<u8> = args
+				.as_ref()
+				.iter()
+				.cloned()
+				.map(|value| match value {
+					wasmi::RuntimeValue::I32(val) => Value::I32(val),
+					wasmi::RuntimeValue::I64(val) => Value::I64(val),
+					wasmi::RuntimeValue::F32(val) => Value::F32(val.into()),
+					wasmi::RuntimeValue::F64(val) => Value::F64(val.into()),
+				})
+				.collect::<Vec<_>>()
+				.encode();
+
+			let state = self.state;
+
+			// Move serialized arguments inside the memory, invoke dispatch thunk and
+			// then free allocated memory.
+			let invoke_args_len = invoke_args_data.len() as WordSize;
+			let invoke_args_ptr = sandbox_context
+				.supervisor_context()
+				.allocate_memory(invoke_args_len)
+				.map_err(|_| trap("Can't allocate memory in supervisor for the arguments"))?;
+
+			let deallocate = |supervisor_context: &mut dyn FunctionContext, ptr, fail_msg| {
+				supervisor_context.deallocate_memory(ptr).map_err(|_| trap(fail_msg))
+			};
+
+			if sandbox_context
+				.supervisor_context()
+				.write_memory(invoke_args_ptr, &invoke_args_data)
+				.is_err()
+			{
+				deallocate(
+					sandbox_context.supervisor_context(),
+					invoke_args_ptr,
+					"Failed dealloction after failed write of invoke arguments",
+				)?;
+				return Err(trap("Can't write invoke args into memory"))
+			}
+
+			let result = sandbox_context.invoke(
+				invoke_args_ptr,
+				invoke_args_len,
+				state,
+				func_idx,
+			);
+
+			deallocate(
+				sandbox_context.supervisor_context(),
+				invoke_args_ptr,
+				"Can't deallocate memory for dispatch thunk's invoke arguments",
+			)?;
+			let result = result.map_err(|_| trap("Could not invoke sandbox"))?;
+
+			// dispatch_thunk returns pointer to serialized arguments.
+			// Unpack pointer and len of the serialized result data.
+			let (serialized_result_val_ptr, serialized_result_val_len) = {
+				// Cast to u64 to use zero-extension.
+				let v = result as u64;
+				let ptr = (v as u64 >> 32) as u32;
+				let len = (v & 0xFFFFFFFF) as u32;
+				(Pointer::new(ptr), len)
+			};
+
+			let serialized_result_val = sandbox_context
+				.supervisor_context()
+				.read_memory(serialized_result_val_ptr, serialized_result_val_len)
+				.map_err(|_| trap("Can't read the serialized result from dispatch thunk"));
+
+			deallocate(
+				sandbox_context.supervisor_context(),
+				serialized_result_val_ptr,
+				"Can't deallocate memory for dispatch thunk's result",
+			)
+				.and(serialized_result_val)
+				.and_then(|serialized_result_val| {
+					let result_val = std::result::Result::<ReturnValue, HostError>::decode(&mut serialized_result_val.as_slice())
+						.map_err(|_| trap("Decoding Result<ReturnValue, HostError> failed!"))?;
+
+					match result_val {
+						Ok(return_value) => Ok(match return_value {
+							ReturnValue::Unit => None,
+							ReturnValue::Value(typed_value) => Some( match typed_value {
+								Value::I32(val) => RuntimeValue::I32(val),
+								Value::I64(val) => RuntimeValue::I64(val),
+								Value::F32(val) => RuntimeValue::F32(val.into()),
+								Value::F64(val) => RuntimeValue::F64(val.into()),
+							}),
+						}),
+						Err(HostError) => Err(trap("Supervisor function returned sandbox::HostError")),
+					}
+				})
+		}).expect("SandboxContextStore is set when invoking sandboxed functions; qed")
+	}
+}
+
+fn with_guest_externals<R, F>(sandbox_instance: &SandboxInstance, state: u32, f: F) -> R
+	where
+		F: FnOnce(&mut GuestExternals) -> R,
+{
+	f(&mut GuestExternals { sandbox_instance, state })
+}
+
+/// Instantiate a module within a sandbox context
+pub fn instantiate(
+	wasm: &[u8],
+	guest_env: GuestEnvironment,
+	state: u32,
+	sandbox_context: &mut dyn SandboxContext,
+) -> std::result::Result<Rc<SandboxInstance>, InstantiationError> {
+	let wasmi_module = Module::from_buffer(wasm).map_err(|_| InstantiationError::ModuleDecoding)?;
+	let wasmi_instance = ModuleInstance::new(&wasmi_module, &guest_env.imports)
+		.map_err(|_| InstantiationError::Instantiation)?;
+
+	let sandbox_instance = Rc::new(SandboxInstance {
+		// In general, it's not a very good idea to use `.not_started_instance()` for
+		// anything but for extracting memory and tables. But in this particular case, we
+		// are extracting for the purpose of running `start` function which should be ok.
+		backend_instance: BackendInstance::Wasmi(wasmi_instance.not_started_instance().clone()),
+		guest_to_supervisor_mapping: guest_env.guest_to_supervisor_mapping,
+	});
+
+	with_guest_externals(&sandbox_instance, state, |guest_externals| {
+		SandboxContextStore::using(sandbox_context, || {
+			wasmi_instance
+				.run_start(guest_externals)
+				.map_err(|_| InstantiationError::StartTrapped)
+		})
+	})?;
+
+	Ok(sandbox_instance)
+}
+
+/// Invoke a function within a sandboxed module
+pub fn invoke(
+	instance: &SandboxInstance,
+	module: &wasmi::ModuleRef,
+	export_name: &str,
+	args: &[Value],
+	state: u32,
+	sandbox_context: &mut dyn SandboxContext,
+) -> std::result::Result<Option<Value>, Error> {
+	with_guest_externals(instance, state, |guest_externals| {
+		SandboxContextStore::using(sandbox_context, || {
+			let args = args.iter().cloned().map(|value| match value {
+				Value::I32(val) => RuntimeValue::I32(val),
+				Value::I64(val) => RuntimeValue::I64(val),
+				Value::F32(val) => RuntimeValue::F32(val.into()),
+				Value::F64(val) => RuntimeValue::F64(val.into()),
+			})
+				.collect::<Vec<_>>();
+
+			module
+				.invoke_export(export_name, &args, guest_externals)
+				.map(|result| { result.map(|value| match value {
+					wasmi::RuntimeValue::I32(val) => Value::I32(val),
+					wasmi::RuntimeValue::I64(val) => Value::I64(val),
+					wasmi::RuntimeValue::F32(val) => Value::F32(val.into()),
+					wasmi::RuntimeValue::F64(val) => Value::F64(val.into()),
+				})
+				})
+				.map_err(|error| Error::Other(error.to_string()))
+		})
+	})
+}
+
+/// Get global value by name
+pub fn get_global(instance: &wasmi::ModuleRef, name: &str) -> Option<Value> {
+	let value = instance.export_by_name(name)?.as_global()?.get();
+	let val = match value {
+		wasmi::RuntimeValue::I32(val) => Value::I32(val),
+		wasmi::RuntimeValue::I64(val) => Value::I64(val),
+		wasmi::RuntimeValue::F32(val) => Value::F32(val.into()),
+		wasmi::RuntimeValue::F64(val) => Value::F64(val.into()),
+	};
+
+	Some(val)
+}


### PR DESCRIPTION
## Description
This PR restores the sandbox host functions that were removed in [Polkadot version v0.9.35](https://github.com/paritytech/substrate/pull/12852/files#) to address the node synchronization issue in full mode.

Changes Introduced in this PR:
1. Reintroduction of Sandbox Host Functions
   Added new files to reinstate the functionality of sandbox host functions:
    - runtime-interface
    - env
    - freeing_bump
    - sandbox_interface
    - sandbox_util
    - wasmi_backend
    - utils
2. Integration with Node Logic 
    Sandbox functions are now called directly from node/client/src/lib.rs to ensure seamless integration.

Notes:

**Dependency on an Older Version of wasmi**
The implementation currently uses version 0.13 of the wasmi library. This decision was made because the recent updates to wasmi involved a complete reimplementation, which resulted in the removal of several functions and types required for sandbox functionality.

**Issue with Host Function Calls**
When attempting to call the host function implementation [here](https://github.com/Cerebellum-Network/blockchain-node/blob/feat/integrating-host-function/node/runtime-interfaces/src/lib.rs#L28), the call (self.sandbox()) traverses through the `sp-runtime_interface` and attempts to access the sandbox function in the `wasm_interface` module. However, this function has been removed from Polkadot SDK, leading to the current challenge.

## Types of Changes
Please select the branch type you are merging and fill in the relevant template.
<!--- Check the following box with an x if the following applies: -->
- [ ] Hotfix
- [ ] Release
- [ ] Fix or Feature

## Fix or Feature
<!--- Check the following box with an x if the following applies: -->

### Types of Changes
<!--- What types of changes does your code introduce? -->
- [ ] Tech Debt (Code improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade (A change in substrate or any 3rd party crate version)

### Migrations and Hooks
<!--- Check the following box with an x if the following applies: -->
- [ ] This change requires a runtime migration.
- [ ] Modifies `on_initialize`
- [ ] Modifies `on_finalize`

### Checklist for Fix or Feature
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been tested locally.
- [ ] Change adds / updates tests if applicable.
- [ ] Changelog doc updated.
- [ ] `spec_version` has been incremented.
- [ ] `network-relayer`'s [events](https://github.com/Cerebellum-Network/network-relayer/blob/dev-cere/shared/substrate/events.go) have been updated according to the blockchain events if applicable.
- [ ] All CI checks have been passed successfully

## Checklist for Hotfix
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been deployed to Testnet.
- [ ] Change has been tested in Testnet.
- [ ] Changelog has been updated.
- [ ] Crate version has been updated.
- [ ] `spec_version` has been incremented.
- [ ] Transaction version has been updated if required.
- [ ] Pull Request to `dev` has been created.
- [ ] Pull Request to `staging` has been created.
- [ ] `network-relayer`'s [events](https://github.com/Cerebellum-Network/network-relayer/blob/dev-cere/shared/substrate/events.go) have been updated according to the blockchain events if applicable.
- [ ] All CI checks have been passed successfully

## Checklist for Release
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [ ] Change has been deployed to Devnet.
- [ ] Change has been tested in Devnet.
- [ ] Change has been deployed to Qanet.
- [ ] Change has been tested in Qanet.
- [ ] Change has been deployed to Testnet.
- [ ] Change has been tested in Testnet.
- [ ] Changelog has been updated.
- [ ] Crate version has been updated.
- [ ] Spec version has been updated.
- [ ] Transaction version has been updated if required.
- [ ] All CI checks have been passed successfully
