### PR TITLE
Allow only one instance of DDC verification OCW to run at a time

### DIFF
--- a/pallets/ddc-verification/src/lib.rs
+++ b/pallets/ddc-verification/src/lib.rs
@@ -43,7 +43,10 @@ use scale_info::prelude::{format, string::String};
 use serde::{Deserialize, Serialize};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_core::crypto::UncheckedFrom;
-pub use sp_io::crypto::sr25519_public_keys;
+pub use sp_io::{
+	crypto::sr25519_public_keys,
+	offchain::{local_storage_get, local_storage_set},
+};
 use sp_runtime::{
 	offchain::{http, Duration, StorageKind},
 	traits::{Hash, IdentifyAccount},
@@ -2417,13 +2420,13 @@ pub mod pallet {
 		pub(crate) fn store_verification_account_id(account_id: T::AccountId) {
 			let validator: Vec<u8> = account_id.encode();
 			let key = format!("offchain::validator::{:?}", DAC_VERIFICATION_KEY_TYPE).into_bytes();
-			sp_io::offchain::local_storage_set(StorageKind::PERSISTENT, &key, &validator);
+			local_storage_set(StorageKind::PERSISTENT, &key, &validator);
 		}
 
 		pub(crate) fn fetch_verification_account_id() -> Result<T::AccountId, OCWError> {
 			let key = format!("offchain::validator::{:?}", DAC_VERIFICATION_KEY_TYPE).into_bytes();
 
-			match sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key) {
+			match local_storage_get(StorageKind::PERSISTENT, &key) {
 				Some(data) => {
 					let account_id = T::AccountId::decode(&mut &data[..])
 						.map_err(|_| OCWError::FailedToFetchVerificationKey)?;
@@ -2459,7 +2462,7 @@ pub mod pallet {
 				.encode();
 
 			// Store the serialized data in local offchain storage
-			sp_io::offchain::local_storage_set(StorageKind::PERSISTENT, &key, &encoded_tuple);
+			local_storage_set(StorageKind::PERSISTENT, &key, &encoded_tuple);
 		}
 
 		pub(crate) fn get_nodes_total_usage(
@@ -2517,11 +2520,10 @@ pub mod pallet {
 			let key = Self::derive_key(cluster_id, era_id);
 
 			// Retrieve encoded tuple from local storage
-			let encoded_tuple =
-				match sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key) {
-					Some(data) => data,
-					None => return None,
-				};
+			let encoded_tuple = match local_storage_get(StorageKind::PERSISTENT, &key) {
+				Some(data) => data,
+				None => return None,
+			};
 
 			// Attempt to decode tuple from bytes
 			match Decode::decode(&mut &encoded_tuple[..]) {
@@ -2550,8 +2552,8 @@ pub mod pallet {
 
 		pub(crate) fn _store_and_fetch_nonce(node_id: String) -> u64 {
 			let key = format!("offchain::activities::nonce::{:?}", node_id).into_bytes();
-			let encoded_nonce = sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, &key)
-				.unwrap_or_else(|| 0.encode());
+			let encoded_nonce =
+				local_storage_get(StorageKind::PERSISTENT, &key).unwrap_or_else(|| 0.encode());
 
 			let nonce_data = match Decode::decode(&mut &encoded_nonce[..]) {
 				Ok(nonce) => nonce,
@@ -2564,7 +2566,7 @@ pub mod pallet {
 
 			let new_nonce = nonce_data + 1;
 
-			sp_io::offchain::local_storage_set(StorageKind::PERSISTENT, &key, &new_nonce.encode());
+			local_storage_set(StorageKind::PERSISTENT, &key, &new_nonce.encode());
 			nonce_data
 		}
 

--- a/pallets/ddc-verification/src/lib.rs
+++ b/pallets/ddc-verification/src/lib.rs
@@ -45,7 +45,9 @@ use sp_application_crypto::RuntimeAppPublic;
 use sp_core::crypto::UncheckedFrom;
 pub use sp_io::{
 	crypto::sr25519_public_keys,
-	offchain::{local_storage_get, local_storage_set},
+	offchain::{
+		local_storage_clear, local_storage_compare_and_set, local_storage_get, local_storage_set,
+	},
 };
 use sp_runtime::{
 	offchain::{http, Duration, StorageKind},
@@ -98,6 +100,8 @@ pub mod pallet {
 	const RESPONSE_TIMEOUT: u64 = 20000;
 	pub const BUCKETS_AGGREGATES_FETCH_BATCH_SIZE: usize = 100;
 	pub const NODES_AGGREGATES_FETCH_BATCH_SIZE: usize = 10;
+	pub const IS_RUNNING_KEY: &[u8] = b"offchain::validator::is_running";
+	pub const IS_RUNNING_VALUE: &[u8] = &[1];
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -721,6 +725,16 @@ pub mod pallet {
 				return;
 			}
 
+			// Allow only one instance of the offchain worker to run at a time.
+			if !local_storage_compare_and_set(
+				StorageKind::PERSISTENT,
+				IS_RUNNING_KEY,
+				None,
+				IS_RUNNING_VALUE,
+			) {
+				return;
+			}
+
 			let verification_key = unwrap_or_log_error!(
 				Self::collect_verification_pub_key(),
 				"❌ Error collecting validator verification key"
@@ -1251,6 +1265,9 @@ pub mod pallet {
 					}
 				}
 			}
+
+			// Allow the next invocation of the offchain worker hook to run.
+			local_storage_clear(StorageKind::PERSISTENT, IS_RUNNING_KEY);
 		}
 	}
 

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 61004,
+	spec_version: 61005,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 23,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1317,7 +1317,7 @@ impl pallet_ddc_verification::Config for Runtime {
 	type OffchainIdentifierId = ddc_primitives::crypto::OffchainIdentifierId;
 	type ActivityHasher = BlakeTwo256;
 	const MAJORITY: u8 = 67;
-	const BLOCK_TO_START: u16 = 30; // every 30 blocks
+	const BLOCK_TO_START: u16 = 1; // every block
 	const DAC_REDUNDANCY_FACTOR: u16 = 3;
 	type AggregatorsQuorum = MajorityOfAggregators;
 	const MAX_PAYOUT_BATCH_SIZE: u16 = MAX_PAYOUT_BATCH_SIZE;

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -147,7 +147,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 61004,
+	spec_version: 61005,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 23,


### PR DESCRIPTION
## Description

This introduces a mutex for `pallet-ddc-verification` OCW to allow only once instance of it to run at a time. It also reduces verification attempts period to a minimum to try to do the verification or progress an era payout each block.

## Types of Changes
Please select the branch type you are merging and fill in the relevant template.
<!--- Check the following box with an x if the following applies: -->
- [ ] Hotfix
- [ ] Release
- [x] Fix or Feature

## Fix or Feature
<!--- Check the following box with an x if the following applies: -->

### Types of Changes
<!--- What types of changes does your code introduce? -->
- [x] Tech Debt (Code improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Dependency upgrade (A change in substrate or any 3rd party crate version)

### Migrations and Hooks
<!--- Check the following box with an x if the following applies: -->
- [ ] This change requires a runtime migration.
- [ ] Modifies `on_initialize`
- [ ] Modifies `on_finalize`

### Checklist for Fix or Feature
<!--- All boxes need to be checked. Follow this checklist before requiring PR review -->
- [x] Change has been tested locally.
- [ ] Change adds / updates tests if applicable.
- [ ] Changelog doc updated.
- [x] `spec_version` has been incremented.
- [ ] `network-relayer`'s [events](https://github.com/Cerebellum-Network/network-relayer/blob/dev-cere/shared/substrate/events.go) have been updated according to the blockchain events if applicable.
- [x] All CI checks have been passed successfully
