### PR TITLE
fix: Remove quotes from PROFILE build args and add jemalloc build dep…

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,7 @@ jobs:
           context: .
           push: true
           build-args: |
-            "PROFILE=${{ env.PROFILE }}"
+            PROFILE=${{ env.PROFILE }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/pos-network-node:${{ env.GITHUB_SHA }}
             ${{ steps.login-ecr.outputs.registry }}/pos-network-node:dev-latest

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -71,7 +71,7 @@ jobs:
           file: Dockerfile
           push: true
           build-args: |
-            "PROFILE=${{ env.PROFILE }}"
+            PROFILE=${{ env.PROFILE }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/pos-network-node:${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/pos-network-node:${{ env.GITHUB_SHA }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     unzip \
     ca-certificates \
+    make \
+    autoconf \
+    automake \
+    libtool \
     && rm -rf /var/lib/apt/lists/*
 
 # sccache disabled - using standard Rust compilation


### PR DESCRIPTION
- Remove quotes from PROFILE build arguments in e2e.yaml and stage.yaml
- Add make, autoconf, automake, libtool to Dockerfile for jemalloc compilation
- Resolves 'failed to execute command: No such file or directory' jemalloc build error"