### PR TITLE
FIX: `cere_dev` missing host function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=003-ddc-dac-host-v1-invoke-stub#f1063e0269ed8a20278ad116184190b0ecc3e11f"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#8f381191ad67f8412d65fb64e4a46ae50392ca2c"
 dependencies = [
  "ddc-api",
  "log",
@@ -5000,7 +5000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6509,7 +6509,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio 1.49.0",
  "tower-service",
  "tracing",
@@ -7081,7 +7081,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=003-ddc-dac-host-v1-invoke-stub#da6d85b9016b16b6a5db32f397ee23f88a38e648"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#bc0033b628579d30f39f58bdad6df5a8cf44962f"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10004,7 +10004,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=003-ddc-dac-host-v1-invoke-stub#e65aad43bf440a9d02ef8b144d8a298efc5faaa1"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#ff4360fb30ecfeece57ef00bbed0347aa4b7ad04"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",
@@ -14212,7 +14212,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14232,7 +14232,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14382,7 +14382,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio 1.49.0",
  "tracing",
@@ -14419,9 +14419,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15273,7 +15273,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15286,7 +15286,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15344,7 +15344,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19424,7 +19424,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21208,7 +21208,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "ddc-api"
 version = "7.3.2"
-source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=dev#8f4b59c6df0df968545a3302bf2fb77ef3b23718"
+source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=dev#48801762039b2c224508e8cbbfb51d7a9b989b09"
 dependencies = [
  "blake2 0.10.6",
  "ddc-primitives",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#db66d07f124ee0b0c69d8243c4de339d826d0563"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=003-ddc-dac-host-v1-invoke-stub#f1063e0269ed8a20278ad116184190b0ecc3e11f"
 dependencies = [
  "ddc-api",
  "log",
@@ -4423,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "ddc-primitives"
 version = "7.3.2"
-source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=dev#dde443c9d86e23a8d4c662b2426db85de448efe6"
+source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=dev#3aba0e702e8d39a98fc0b38ea5e3e1e315371e35"
 dependencies = [
  "blake2 0.10.6",
  "frame-support",
@@ -5000,7 +5000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6509,7 +6509,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio 1.49.0",
  "tower-service",
  "tracing",
@@ -7081,7 +7081,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#febb70de1fa41b57fe436e2a25b877247dccac47"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=003-ddc-dac-host-v1-invoke-stub#da6d85b9016b16b6a5db32f397ee23f88a38e648"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10004,7 +10004,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#e2d68d4f4242038e1e8527cd27eff1ae4c36f579"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=003-ddc-dac-host-v1-invoke-stub#e65aad43bf440a9d02ef8b144d8a298efc5faaa1"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",
@@ -14212,7 +14212,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14232,7 +14232,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14382,7 +14382,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio 1.49.0",
  "tracing",
@@ -14419,9 +14419,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15273,7 +15273,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15286,7 +15286,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15344,7 +15344,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -19424,7 +19424,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -21208,7 +21208,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,9 +201,9 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
 ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
 
 # Hyperbridge (polkadot-stable2512)
 ismp = { default-features = false, version = "2512.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,9 +201,9 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
 ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "003-ddc-dac-host-v1-invoke-stub", default-features = false }
 
 # Hyperbridge (polkadot-stable2512)
 ismp = { default-features = false, version = "2512.0.0" }


### PR DESCRIPTION
## What

Cargo.toml branch-pin + Cargo.lock bumps to pick up the v1 invoke host-function stub across the DDC chain stack:

- `ddc-dac-host` → [`f1063e02`](https://github.com/Cerebellum-Network/ddc-dac-host/pull/6)
- `pallet-ddc-verification` → [`e65aad43`](https://github.com/Cerebellum-Network/ddc-verification/pull/57)
- `pallet-ddc-payouts` → [`da6d85b9`](https://github.com/Cerebellum-Network/ddc-payouts/pull/61)

Plus a fresh `cere-runtime` / `cere-dev-runtime` release build (`Finished release profile [optimized] target(s) in 4m 17s`).

## Why

Devnet node-client upgrades currently fail at preinstantiation:

```
WARN main wasm-runtime: Cannot create a runtime
  error=Other("cannot preinstantiate module: incompatible import type
              for env::ext_ddc_dac_invoke_version_1:
              expected (func (param i64) (result i64)),
              found (func (param i64 i64) (result i64))")
ERROR tokio-runtime-worker sc_service::task_manager: Essential task `txpool-background` failed. Shutting down service.
```

Root cause: `ddc-dac-host` PR #1 changed `invoke`'s signature from `(payload)` to `(session_id, payload)` without versioning the host entry, so the new client exports `ext_ddc_dac_invoke_version_1` with the wrong signature for runtime wasms compiled before sessions. The fix in [ddc-dac-host#6](https://github.com/Cerebellum-Network/ddc-dac-host/pull/6) splits the entry into `#[version(1)]` stub (matches old sig) + `#[version(2)]` (real implementation), so old chain-stored runtimes preinstantiate cleanly and the runtime built here imports v2.

## Effects

- New node binary built off this branch unblocks Devnet upgrade — node boots against the existing chain-stored runtime; governance can then push `set_code` to install the runtime built here, which imports `ext_ddc_dac_invoke_version_2`.
- Mainnet (`cere`) runtime never shipped the old invoke host function (it predates the DDC chain extension), so the cere binary path needs experimental verification but is expected to be unaffected. Will check before promoting past Devnet.

## Test plan

- [x] `cargo build --release -p cere-runtime` — clean, 4m 17s
- [ ] Boot the new client against current Devnet chain state — should preinstantiate runtime + start producing blocks
- [ ] Push `set_code` via OpenGov to install the runtime wasm from this build
- [ ] Confirm `era_applyInspectionRcptToEhd` / `era_verifyInspectionRcpt` / aggregator calls work after upgrade
- [ ] Repeat on Testnet
- [ ] Verify mainnet `cere` runtime boots against new client experimentally (old host function never shipped there, but verify before promoting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)