### PR TITLE
Dynamic OCW wasm heap + --ocw-heap-pages flag

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -27,6 +27,12 @@ pub struct RunCmd {
 	/// telemetry, if telemetry is enabled.
 	#[arg(long)]
 	pub no_hardware_benchmarks: bool,
+
+	/// Maximum wasm linear-memory pages (each page is 64 KB) for offchain
+	/// worker execution. The default is 8192 (= 512 MB ceiling); memory grows
+	/// on demand up to this value. Does not affect on-chain wasm execution.
+	#[arg(long)]
+	pub ocw_heap_pages: Option<u32>,
 }
 
 #[allow(missing_docs, clippy::large_enum_variant)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -227,6 +227,7 @@ pub fn run() -> sc_cli::Result<()> {
 				cere_service::build_full::<sc_network::Litep2pNetworkBackend>(
 					config,
 					cli.run.no_hardware_benchmarks,
+					cli.run.ocw_heap_pages,
 				)
 				.map(|full| full.task_manager)
 				.map_err(Error::Service)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -97,6 +97,7 @@ where
 #[allow(clippy::result_large_err)]
 fn new_partial_basics<RuntimeApi>(
 	config: &Configuration,
+	ocw_heap_pages: Option<u32>,
 ) -> Result<Basics<RuntimeApi>, ServiceError>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi>> + Send + Sync + 'static,
@@ -113,15 +114,25 @@ where
 		})
 		.transpose()?;
 
-	let heap_pages = config
+	// On-chain heap: keep upstream behaviour (Static{2048} = 128 MB). Runtime
+	// upgrades and sudo via `system.setHeapPages` retain the existing override
+	// path through the `:heappages` storage key.
+	let onchain_heap_pages = config
 		.executor
 		.default_heap_pages
 		.map_or(DEFAULT_HEAP_ALLOC_STRATEGY, |h| HeapAllocStrategy::Static { extra_pages: h as _ });
 
+	// Off-chain (OCW) heap: Dynamic growth up to 8192 pages (512 MB) by default,
+	// overridable per-validator via `--ocw-heap-pages N`. Memory commits on
+	// demand, so steady-state RSS does not change when OCWs are idle.
+	let offchain_heap_pages = HeapAllocStrategy::Dynamic {
+		maximum_pages: Some(ocw_heap_pages.unwrap_or(8192)),
+	};
+
 	let executor = ChainExecutor::builder()
 		.with_execution_method(config.executor.wasm_method)
-		.with_onchain_heap_alloc_strategy(heap_pages)
-		.with_offchain_heap_alloc_strategy(heap_pages)
+		.with_onchain_heap_alloc_strategy(onchain_heap_pages)
+		.with_offchain_heap_alloc_strategy(offchain_heap_pages)
 		.with_max_runtime_instances(config.executor.max_runtime_instances)
 		.with_runtime_cache_size(config.executor.runtime_cache_size)
 		.build();
@@ -284,12 +295,14 @@ where
 pub fn build_full<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	config: Configuration,
 	disable_hardware_benchmarks: bool,
+	ocw_heap_pages: Option<u32>,
 ) -> Result<NewFull<Client>, ServiceError> {
 	#[cfg(feature = "cere-dev-native")]
 	if config.chain_spec.is_cere_dev() {
 		return new_full::<cere_dev_runtime::RuntimeApi, N>(
 			config,
 			disable_hardware_benchmarks,
+			ocw_heap_pages,
 			|_, _| (),
 		)
 		.map(|full| full.with_client(Client::CereDev));
@@ -297,8 +310,13 @@ pub fn build_full<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 
 	#[cfg(feature = "cere-native")]
 	{
-		new_full::<cere_runtime::RuntimeApi, N>(config, disable_hardware_benchmarks, |_, _| ())
-			.map(|full| full.with_client(Client::Cere))
+		new_full::<cere_runtime::RuntimeApi, N>(
+			config,
+			disable_hardware_benchmarks,
+			ocw_heap_pages,
+			|_, _| (),
+		)
+		.map(|full| full.with_client(Client::Cere))
 	}
 
 	#[cfg(not(feature = "cere-native"))]
@@ -330,6 +348,7 @@ impl<C> NewFull<C> {
 pub fn new_full<RuntimeApi, N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	config: Configuration,
 	disable_hardware_benchmarks: bool,
+	ocw_heap_pages: Option<u32>,
 	with_startup_data: impl FnOnce(
 		&FullBabeBlockImport<RuntimeApi>,
 		&sc_consensus_babe::BabeLink<Block>,
@@ -348,7 +367,7 @@ where
 		None
 	};
 
-	let basics = new_partial_basics::<RuntimeApi>(&config)?;
+	let basics = new_partial_basics::<RuntimeApi>(&config, ocw_heap_pages)?;
 
 	let sc_service::PartialComponents {
 		client,
@@ -626,7 +645,9 @@ impl ExecuteWithClient for RevertConsensus {
 macro_rules! chain_ops {
 	($config:expr; $scope:ident, $variant:ident) => {{
 		let config = $config;
-		let basics = new_partial_basics::<$scope::RuntimeApi>(config)?;
+		// Offline subcommands don't run OCWs; the OCW heap-pages override is
+		// irrelevant here, so we pass None and fall back to the chart default.
+		let basics = new_partial_basics::<$scope::RuntimeApi>(config, None)?;
 
 		let sc_service::PartialComponents { client, backend, import_queue, task_manager, .. } =
 			new_partial::<$scope::RuntimeApi>(&config, basics)?;


### PR DESCRIPTION
## Summary

The default offchain heap allocator was `HeapAllocStrategy::Static { extra_pages: 2048 }` — a hard 128 MB preallocated cap. OCWs that decode large protobuf payloads (e.g. ddc-verification's assignment-table fetch on clusters with many paths) trap when they exceed it. A wasm trap inside an OCW leaves the persistent `OcwMutex` stuck at `LOCKED_VALUE`, blocking every subsequent inspection trigger on that validator until the mutex is manually cleared.

This PR splits the heap strategy between on-chain and off-chain contexts so the OCW gets headroom without changing on-chain behaviour.

## Changes

- **`node/service/src/lib.rs`** — `new_partial_basics` now computes two strategies:
  - **on-chain**: unchanged. `DEFAULT_HEAP_ALLOC_STRATEGY` (`Static{2048}` = 128 MB). `system.setHeapPages` extrinsic and runtime-side overrides keep working exactly as before via the `:heappages` storage key.
  - **off-chain**: `Dynamic { maximum_pages: Some(8192) }` (= 512 MB ceiling) by default, overridable per-validator via CLI. Memory commits on demand, so steady-state validator RSS does not change when OCWs are idle.
  - `new_partial_basics`, `new_full`, `build_full` each take a new `ocw_heap_pages: Option<u32>` argument.
  - `chain_ops!` (offline subcommands like `CheckBlock` / `ExportBlocks`) passes `None` since those don't run OCWs.
- **`node/cli/src/cli.rs`** — new `--ocw-heap-pages N` flag on Cere's `RunCmd`. Default 8192.
- **`node/cli/src/command.rs`** — `None =>` arm (validator `run` path) plumbs `cli.run.ocw_heap_pages` into `build_full`.

## Usage

```bash
pos-node                            # 512 MB off-chain ceiling (default)
pos-node --ocw-heap-pages 16384     # 1 GB off-chain ceiling
```

## Safety properties

Both `Dynamic` and `Static` trap deterministically at their ceiling (verified by upstream `sc-executor-wasmtime` unit tests at `tests.rs:443-453`). Switching from Static to Dynamic preserves:

- Deterministic termination at the cap (wasm trap → OCW host-call error).
- Wasmtime bounds-checking + guard pages.
- Determinism across validators (independent of host strategy).

Behaviour for OCWs that fit within 128 MB today: byte-for-byte identical (no `memory.grow` is ever called).
Behaviour for OCWs that previously trapped at 128 MB: now succeed up to the new ceiling.

## Test plan

- [x] `cargo check --release -p cere-cli` passes
- [x] Build a `pos-node` image, deploy to one testnet validator, confirm `--ocw-heap-pages` is accepted and that the next inspection-OCW tick for cluster `0x223355…` era 494268 succeeds instead of orphaning the inspection mutex