### PR TITLE
feat: wire DacExecConfig pallet constant into cere + cere-dev runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,11 +4409,13 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#8f381191ad67f8412d65fb64e4a46ae50392ca2c"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=feat%2Fdac-exec-config#27993d246e5d6c688db1b0f157e9476579a66a2c"
 dependencies = [
  "ddc-api",
  "log",
+ "parity-scale-codec",
  "prost 0.13.5",
+ "scale-info",
  "sp-core",
  "sp-runtime-interface",
  "sp-std",
@@ -5000,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6509,7 +6511,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio 1.49.0",
  "tower-service",
  "tracing",
@@ -7081,7 +7083,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9943,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#5a7bf8128ac97a810839b9034257545803779561"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=feat%2Fdac-exec-config#99ad9ec7d3688f8076d8a6c60a0dc2210452a287"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10004,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#ff4360fb30ecfeece57ef00bbed0347aa4b7ad04"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=feat%2Fdac-exec-config#29cd6efd5626bcc758dc156de767971556618a0d"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",
@@ -14212,7 +14214,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14232,7 +14234,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14382,7 +14384,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio 1.49.0",
  "tracing",
@@ -14419,9 +14421,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15273,7 +15275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15286,7 +15288,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15344,7 +15346,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19424,7 +19426,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21208,7 +21210,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=feat%2Fdac-exec-config#27993d246e5d6c688db1b0f157e9476579a66a2c"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#b1610aaae99c79f9c7435e31e89ba3bba81cdcb5"
 dependencies = [
  "ddc-api",
  "log",
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=feat%2Fdac-exec-config#99ad9ec7d3688f8076d8a6c60a0dc2210452a287"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#40c37a5bf483e14183bedfe045d582bb898b8c2d"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10006,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=feat%2Fdac-exec-config#29cd6efd5626bcc758dc156de767971556618a0d"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#de421b0a31e14b83c3c051e01593932d6410f4cc"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,9 +201,9 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
 ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "feat/dac-exec-config", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "feat/dac-exec-config", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "feat/dac-exec-config", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
 
 # Hyperbridge (polkadot-stable2512)
 ismp = { default-features = false, version = "2512.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,9 +201,9 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
 ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "feat/dac-exec-config", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "feat/dac-exec-config", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "feat/dac-exec-config", default-features = false }
 
 # Hyperbridge (polkadot-stable2512)
 ismp = { default-features = false, version = "2512.0.0" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -125,9 +125,8 @@ where
 	// Off-chain (OCW) heap: Dynamic growth up to 8192 pages (512 MB) by default,
 	// overridable per-validator via `--ocw-heap-pages N`. Memory commits on
 	// demand, so steady-state RSS does not change when OCWs are idle.
-	let offchain_heap_pages = HeapAllocStrategy::Dynamic {
-		maximum_pages: Some(ocw_heap_pages.unwrap_or(8192)),
-	};
+	let offchain_heap_pages =
+		HeapAllocStrategy::Dynamic { maximum_pages: Some(ocw_heap_pages.unwrap_or(8192)) };
 
 	let executor = ChainExecutor::builder()
 		.with_execution_method(config.executor.wasm_method)

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1399,6 +1399,33 @@ impl<T: frame_system::Config> PalletVisitor<T> for TreasuryWrapper {
 	}
 }
 
+parameter_types! {
+	/// Wasmtime tunables for the dac.wasm executor used by ddc-payouts and
+	/// ddc-verification OCWs. See `ddc_dac_host::DacExecConfig` for field
+	/// semantics. Tuning is runtime-upgrade-only — no node-binary rebuild.
+	///
+	/// Cere-dev defaults: diagnostics ON (coredumps + detailed backtraces
+	/// + DWARF debug info preserved) so the next dac.wasm trap captures
+	/// a forensic-quality snapshot. Per-invoke deadline 60 s, 256 MiB
+	/// linear-memory cap. Override in chain-spec for stricter testing.
+	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
+		invoke_deadline_ms: 60_000,
+		epoch_tick_ms: 250,
+		fuel_per_invoke: None,
+		max_wasm_stack_bytes: 2 * 1024 * 1024,
+		max_memory_bytes: 256 * 1024 * 1024,
+		memory_guard_size: 2 * 1024 * 1024,
+		memory_reservation: 4 * 1024 * 1024 * 1024,
+		memory_init_cow: true,
+		cranelift_opt_level: ddc_dac_host::CraneliftOptLevel::Speed,
+		parallel_compilation: true,
+		coredump_on_trap: true,
+		wasm_backtrace: true,
+		wasm_backtrace_details: true,
+		debug_info: true,
+	};
+}
+
 impl pallet_ddc_payouts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_ddc_payouts::weights::SubstrateWeight<Runtime>;
@@ -1427,6 +1454,7 @@ impl pallet_ddc_payouts::Config for Runtime {
 	#[cfg(feature = "runtime-benchmarks")]
 	type WSignature = Signature;
 	type UnsignedPriority = ConstU64<500_000_000>;
+	type DacExecConfig = DacExecConfigConst;
 	type FeeHandler = FeeHandler;
 	type ForcePayoutOrigin = pallet_ddc_payouts::EnsureRootOrClusterManagerForForcePayout<Runtime>;
 
@@ -1531,6 +1559,7 @@ impl pallet_ddc_verification::Config for Runtime {
 
 	type InspRedundancyFactor = TenPercentOfValidators;
 	type InspBackupsFactor = TenPercentOfValidators;
+	type DacExecConfig = DacExecConfigConst;
 
 	const OCW_INTERVAL: u16 = 1; // every 10th block
 	const TCA_INSPECTION_STEP: u64 = 0;

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -172,7 +172,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80006,
+	spec_version: 80007,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1401,19 +1401,23 @@ impl<T: frame_system::Config> PalletVisitor<T> for TreasuryWrapper {
 
 parameter_types! {
 	/// Wasmtime tunables for the dac.wasm executor used by ddc-payouts and
-	/// ddc-verification OCWs. See `ddc_dac_host::DacExecConfig` for field
-	/// semantics. Tuning is runtime-upgrade-only — no node-binary rebuild.
+	/// ddc-verification OCWs. Runtime-upgrade-tunable; see
+	/// `ddc_dac_host::DacExecConfig` for field semantics.
 	///
-	/// Cere-dev defaults: diagnostics ON (coredumps + detailed backtraces
-	/// + DWARF debug info preserved) so the next dac.wasm trap captures
-	/// a forensic-quality snapshot. Per-invoke deadline 60 s, 256 MiB
-	/// linear-memory cap. Override in chain-spec for stricter testing.
+	/// Cere-dev (testnet/devnet) values: same resource ceilings as
+	/// mainnet (5-min per-invoke deadline, 512 MiB linear-memory cap,
+	/// 4 GiB virtual reservation, 4 MiB stack) — sized to handle the
+	/// largest tables observed while staying safe on 8 GiB validator
+	/// hosts. Diagnostics fully ON — coredumps written to
+	/// /data/dac-coredumps/ on trap, detailed backtraces, DWARF debug
+	/// info preserved through Cranelift. The next dac.wasm trap on
+	/// testnet drops a forensic snapshot for `wasmtime explore`.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
-		invoke_deadline_ms: 60_000,
+		invoke_deadline_ms: 300_000,
 		epoch_tick_ms: 250,
 		fuel_per_invoke: None,
-		max_wasm_stack_bytes: 2 * 1024 * 1024,
-		max_memory_bytes: 256 * 1024 * 1024,
+		max_wasm_stack_bytes: 4 * 1024 * 1024,
+		max_memory_bytes: 512 * 1024 * 1024,
 		memory_guard_size: 2 * 1024 * 1024,
 		memory_reservation: 4 * 1024 * 1024 * 1024,
 		memory_init_cow: true,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1401,17 +1401,25 @@ impl<T: frame_system::Config> PalletVisitor<T> for TreasuryWrapper {
 
 parameter_types! {
 	/// Wasmtime tunables for the dac.wasm executor used by ddc-payouts and
-	/// ddc-verification OCWs. Runtime-upgrade-tunable; see
+	/// ddc-verification OCWs. Each field is runtime-upgrade tunable; see
 	/// `ddc_dac_host::DacExecConfig` for field semantics.
 	///
-	/// Cere-dev (testnet/devnet) values: same resource ceilings as
-	/// mainnet (5-min per-invoke deadline, 512 MiB linear-memory cap,
-	/// 4 GiB virtual reservation, 4 MiB stack) — sized to handle the
-	/// largest tables observed while staying safe on 8 GiB validator
-	/// hosts. Diagnostics fully ON — coredumps written to
-	/// /data/dac-coredumps/ on trap, detailed backtraces, DWARF debug
-	/// info preserved through Cranelift. The next dac.wasm trap on
-	/// testnet drops a forensic snapshot for `wasmtime explore`.
+	/// Comfortable headroom over wasmtime defaults without committing
+	/// huge resources on small validator hosts:
+	///   * 5-min per-invoke deadline — only fires on genuine runaway
+	///     loops; healthy single-invoke ops complete in milliseconds.
+	///   * 512 MiB linear-memory hard cap — 2x previous, comfortably
+	///     above proto decode + clone + canonical-hash for the largest
+	///     tables observed (4 MiB proto + structural expansion).
+	///   * 4 GiB virtual reservation — wasmtime-typical, no physical
+	///     RAM until pages are touched. Stays safe on 8 GiB hosts.
+	///   * 4 MiB wasm stack — bounds runaway recursion without
+	///     affecting normal depths.
+	/// Diagnostics fully ON — on a dac.wasm trap, the host writes a
+	/// WasmCoreDump to /data/dac-coredumps/ for post-mortem analysis
+	/// via `wasmtime explore`, DWARF debug info is preserved through
+	/// Cranelift, and trap backtraces include source-level detail.
+	/// Can be flipped off via runtime upgrade once the system stabilises.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
 		invoke_deadline_ms: 300_000,
 		epoch_tick_ms: 250,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1365,6 +1365,32 @@ impl<T: frame_system::Config> PalletVisitor<T> for TreasuryWrapper {
 	}
 }
 
+parameter_types! {
+	/// Wasmtime tunables for the dac.wasm executor used by ddc-payouts and
+	/// ddc-verification OCWs. Each field can be tuned at runtime-upgrade
+	/// time without rebuilding the node binary; see `ddc_dac_host::DacExecConfig`
+	/// for field semantics.
+	///
+	/// Mainnet defaults: diagnostics off (no coredumps, minimal backtrace),
+	/// per-invoke deadline 60 s, 256 MiB linear-memory cap.
+	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
+		invoke_deadline_ms: 60_000,
+		epoch_tick_ms: 250,
+		fuel_per_invoke: None,
+		max_wasm_stack_bytes: 2 * 1024 * 1024,
+		max_memory_bytes: 256 * 1024 * 1024,
+		memory_guard_size: 2 * 1024 * 1024,
+		memory_reservation: 4 * 1024 * 1024 * 1024,
+		memory_init_cow: true,
+		cranelift_opt_level: ddc_dac_host::CraneliftOptLevel::Speed,
+		parallel_compilation: true,
+		coredump_on_trap: false,
+		wasm_backtrace: true,
+		wasm_backtrace_details: false,
+		debug_info: false,
+	};
+}
+
 impl pallet_ddc_payouts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_ddc_payouts::weights::SubstrateWeight<Runtime>;
@@ -1385,6 +1411,7 @@ impl pallet_ddc_payouts::Config for Runtime {
 	type ClusterManager = DdcClusters;
 	type OffchainIdentifierId = ddc_primitives::crypto::OffchainIdentifierId;
 	type UnsignedPriority = ConstU64<500_000_000>;
+	type DacExecConfig = DacExecConfigConst;
 	type FeeHandler = FeeHandler;
 	type ForcePayoutOrigin = pallet_ddc_payouts::EnsureRootForForcePayout<AccountId>;
 
@@ -1514,6 +1541,7 @@ impl pallet_ddc_verification::Config for Runtime {
 
 	type InspRedundancyFactor = TenPercentOfValidators;
 	type InspBackupsFactor = TenPercentOfValidators;
+	type DacExecConfig = DacExecConfigConst;
 
 	const OCW_INTERVAL: u16 = 10; // every 10th block
 	const TCA_INSPECTION_STEP: u64 = 0;

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1370,8 +1370,8 @@ parameter_types! {
 	/// ddc-verification OCWs. Each field is runtime-upgrade tunable; see
 	/// `ddc_dac_host::DacExecConfig` for field semantics.
 	///
-	/// Mainnet values — comfortable headroom over wasmtime defaults
-	/// without committing huge resources on small validator hosts:
+	/// Comfortable headroom over wasmtime defaults without committing
+	/// huge resources on small validator hosts:
 	///   * 5-min per-invoke deadline — only fires on genuine runaway
 	///     loops; healthy single-invoke ops complete in milliseconds.
 	///   * 512 MiB linear-memory hard cap — 2x previous, comfortably
@@ -1381,9 +1381,11 @@ parameter_types! {
 	///     RAM until pages are touched. Stays safe on 8 GiB hosts.
 	///   * 4 MiB wasm stack — bounds runaway recursion without
 	///     affecting normal depths.
-	/// Diagnostics off to keep mainnet logs lean and the runtime wasm
-	/// blob small. `coredump_on_trap` etc. can be flipped via runtime
-	/// upgrade if a post-mortem becomes necessary.
+	/// Diagnostics fully ON — on a dac.wasm trap, the host writes a
+	/// WasmCoreDump to /data/dac-coredumps/ for post-mortem analysis
+	/// via `wasmtime explore`, DWARF debug info is preserved through
+	/// Cranelift, and trap backtraces include source-level detail.
+	/// Can be flipped off via runtime upgrade once the system stabilises.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
 		invoke_deadline_ms: 300_000,
 		epoch_tick_ms: 250,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1395,10 +1395,10 @@ parameter_types! {
 		memory_init_cow: true,
 		cranelift_opt_level: ddc_dac_host::CraneliftOptLevel::Speed,
 		parallel_compilation: true,
-		coredump_on_trap: false,
+		coredump_on_trap: true,
 		wasm_backtrace: true,
-		wasm_backtrace_details: false,
-		debug_info: false,
+		wasm_backtrace_details: true,
+		debug_info: true,
 	};
 }
 

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80006,
+	spec_version: 80007,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1367,18 +1367,29 @@ impl<T: frame_system::Config> PalletVisitor<T> for TreasuryWrapper {
 
 parameter_types! {
 	/// Wasmtime tunables for the dac.wasm executor used by ddc-payouts and
-	/// ddc-verification OCWs. Each field can be tuned at runtime-upgrade
-	/// time without rebuilding the node binary; see `ddc_dac_host::DacExecConfig`
-	/// for field semantics.
+	/// ddc-verification OCWs. Each field is runtime-upgrade tunable; see
+	/// `ddc_dac_host::DacExecConfig` for field semantics.
 	///
-	/// Mainnet defaults: diagnostics off (no coredumps, minimal backtrace),
-	/// per-invoke deadline 60 s, 256 MiB linear-memory cap.
+	/// Mainnet values — comfortable headroom over wasmtime defaults
+	/// without committing huge resources on small validator hosts:
+	///   * 5-min per-invoke deadline — only fires on genuine runaway
+	///     loops; healthy single-invoke ops complete in milliseconds.
+	///   * 512 MiB linear-memory hard cap — 2x previous, comfortably
+	///     above proto decode + clone + canonical-hash for the largest
+	///     tables observed (4 MiB proto + structural expansion).
+	///   * 4 GiB virtual reservation — wasmtime-typical, no physical
+	///     RAM until pages are touched. Stays safe on 8 GiB hosts.
+	///   * 4 MiB wasm stack — bounds runaway recursion without
+	///     affecting normal depths.
+	/// Diagnostics off to keep mainnet logs lean and the runtime wasm
+	/// blob small. `coredump_on_trap` etc. can be flipped via runtime
+	/// upgrade if a post-mortem becomes necessary.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
-		invoke_deadline_ms: 60_000,
+		invoke_deadline_ms: 300_000,
 		epoch_tick_ms: 250,
 		fuel_per_invoke: None,
-		max_wasm_stack_bytes: 2 * 1024 * 1024,
-		max_memory_bytes: 256 * 1024 * 1024,
+		max_wasm_stack_bytes: 4 * 1024 * 1024,
+		max_memory_bytes: 512 * 1024 * 1024,
 		memory_guard_size: 2 * 1024 * 1024,
 		memory_reservation: 4 * 1024 * 1024 * 1024,
 		memory_init_cow: true,


### PR DESCRIPTION
`parameter_types! { DacExecConfigConst: DacExecConfig = ... }` in both runtimes, wired into ddc-verification + ddc-payouts pallet impls. Mainnet: diagnostics off. Cere-dev: coredumps + DWARF + detailed backtrace on for testnet forensics. Cascade lockfile bumps for ddc-dac-host, pallet-ddc-verification, pallet-ddc-payouts. After this lands, any wasmtime knob is tunable via runtime upgrade alone — no node-binary rebuild.