### PR TITLE
Release/80008

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#b1610aaae99c79f9c7435e31e89ba3bba81cdcb5"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#1c5105e5fd28b738a78cd884736d764b8411a21e"
 dependencies = [
  "ddc-api",
  "log",
@@ -5002,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6511,7 +6511,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio 1.49.0",
  "tower-service",
  "tracing",
@@ -7083,7 +7083,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#40c37a5bf483e14183bedfe045d582bb898b8c2d"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#f730c9f3d894087040224561db4f0e0f2da57114"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10006,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#de421b0a31e14b83c3c051e01593932d6410f4cc"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#185c01517cb5f189bb00f60712677ae987756a88"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",
@@ -14214,7 +14214,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14234,7 +14234,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14384,7 +14384,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio 1.49.0",
  "tracing",
@@ -14421,9 +14421,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15275,7 +15275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15288,7 +15288,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15346,7 +15346,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -19426,7 +19426,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -21210,7 +21210,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -172,7 +172,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80007,
+	spec_version: 80008,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1421,7 +1421,7 @@ parameter_types! {
 	/// Cranelift, and trap backtraces include source-level detail.
 	/// Can be flipped off via runtime upgrade once the system stabilises.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
-		invoke_deadline_ms: 300_000,
+		invoke_deadline_ms: 600_000,
 		epoch_tick_ms: 250,
 		fuel_per_invoke: None,
 		max_wasm_stack_bytes: 4 * 1024 * 1024,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80007,
+	spec_version: 80008,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1387,7 +1387,7 @@ parameter_types! {
 	/// Cranelift, and trap backtraces include source-level detail.
 	/// Can be flipped off via runtime upgrade once the system stabilises.
 	pub DacExecConfigConst: ddc_dac_host::DacExecConfig = ddc_dac_host::DacExecConfig {
-		invoke_deadline_ms: 300_000,
+		invoke_deadline_ms: 600_000,
 		epoch_tick_ms: 250,
 		fuel_per_invoke: None,
 		max_wasm_stack_bytes: 4 * 1024 * 1024,


### PR DESCRIPTION
## Summary
Promotes dev → staging for the 80008 runtime upgrade.

**Cargo.lock bumps** (all three ddc-* deps to their staging tips, post the release/80008 cascade in those repos):
- `ddc-dac-host` → `d0650e1` (carries [ddc-dac-host#11](https://github.com/Cerebellum-Network/ddc-dac-host/pull/11) → per-invoke `→`/`←` trace markers around every `ddc_dac::invoke`)
- `pallet-ddc-verification` → `0286bc3` ([ddc-verification#62](https://github.com/Cerebellum-Network/ddc-verification/pull/62))
- `pallet-ddc-payouts` → `b775851` ([ddc-payouts#68](https://github.com/Cerebellum-Network/ddc-payouts/pull/68))

**Runtime knobs** (both `runtime/cere` + `runtime/cere-dev`):
- `spec_version`: 80007 → 80008 (required for runtime upgrade acceptance)
- `DacExecConfigConst.invoke_deadline_ms`: 300_000 → 600_000 (5 min → 10 min) — gives the dac.wasm slow path on era 494268 more runway before the wasmtime epoch deadline trips; if it completes in 6–7 min the era unblocks for free, otherwise the new trace logs identify the slow selector

**Merge content**: staging-side commits brought in cleanly (CI workflows, CHANGELOG, `pallets/ddc-clusters/src/migrations.rs`, docs). Cargo.toml branch pins follow staging convention.

## Test plan
- [ ] `cargo build --release -p cere-runtime` passes (verified locally — `Finished `release` profile [optimized] target(s) in 1m 42s`)
- [ ] Build pos-node Docker image from this branch
- [ ] Runtime upgrade on Testnet via `set_code` with the new `cere-runtime.wasm`
- [ ] Verify post-upgrade OCW logs show `→ session=N sel=X payload_len=M` / `← session=N sel=X resp_len=M status=K` trace pairs around each dac.wasm invoke
- [ ] Within ~10 min of fresh OCW lock acquisition on era 494268: either era progresses to completion, OR a slow selector is visible with `→` and no matching `←` before the next trap