### PR TITLE
release/80009: bump ddc-* deps + spec_version 80009

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#1c5105e5fd28b738a78cd884736d764b8411a21e"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#7b56ddac48da503682ef12f7fcae3954507b7d2a"
 dependencies = [
  "ddc-api",
  "log",
@@ -5002,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6511,7 +6511,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite 0.2.16",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio 1.49.0",
  "tower-service",
  "tracing",
@@ -7083,7 +7083,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#f730c9f3d894087040224561db4f0e0f2da57114"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#294291f875b01e3d51773d710f51856a7ba849b2"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10006,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.0"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#185c01517cb5f189bb00f60712677ae987756a88"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#8d04eba3af1e0ab225e5368d9e039d2a2ebd95cb"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",
@@ -14214,7 +14214,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14234,7 +14234,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -14384,7 +14384,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio 1.49.0",
  "tracing",
@@ -14421,9 +14421,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15275,7 +15275,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15288,7 +15288,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15346,7 +15346,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19426,7 +19426,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21210,7 +21210,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -172,7 +172,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80008,
+	spec_version: 80009,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80008,
+	spec_version: 80009,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,


### PR DESCRIPTION
## Summary
Promotes dev → staging for the 80009 runtime upgrade.

**Cargo.lock bumps** (all three ddc-* deps to their staging tips):
- `ddc-dac-host` → `3ff3250e` (carries [ddc-dac-host#14](https://github.com/Cerebellum-Network/ddc-dac-host/pull/14) — dachost.log host import + process-global MODULE_CACHE fix)
- `pallet-ddc-verification` → `5ce1e9ef` ([ddc-verification#64](https://github.com/Cerebellum-Network/ddc-verification/pull/64))
- `pallet-ddc-payouts` → `da36d35b` ([ddc-payouts#70](https://github.com/Cerebellum-Network/ddc-payouts/pull/70))

**Runtime knobs** (both `runtime/cere` + `runtime/cere-dev`):
- `spec_version`: 80008 → 80009 (carried in from dev — required for runtime upgrade)
- `DacExecConfigConst.invoke_deadline_ms`: 600_000 (10 min)

**Merge content**: clean (Cargo.lock conflict on dep SHAs resolved by taking staging then `cargo update`; runtime/cere/src/lib.rs auto-merged).

## Test plan
- [x] `cargo build --release -p cere-runtime` passes (1m 47s)
- [ ] pos-node Docker image rebuild from this branch (the new `dachost.log` host stub lives in `ddc-dac-host`'s native code — paired client+runtime upgrade, not runtime-only)
- [ ] Testnet `set_code` with the new `cere-runtime.wasm`
- [ ] Confirm `[wasm] ...` lines appear in OCW logs under target `ddc-dac-host`
- [ ] On next OCW lock acquisition: observe which inner step of `doNodeAggCreateState` is the slow one when the 10-min trap fires