### PR TITLE
ci(manual-build): use env vars instead of hardcoded image name

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -51,16 +51,16 @@ jobs:
       matrix:
         platform: ${{ fromJSON(needs.prepare.outputs.platforms) }}
     steps:
-      - name: "Prune old pos-node images"
+      - name: "Prune old ${{ env.PACKAGE_NAME }} images"
         run: |
           set -x
           df -h /
-          # Self-hosted runner accumulates pos-node images from prior
-          # builds and eventually hits "No space left on device"
-          # mid-build. Drop ONLY images tagged under our repository —
-          # buildx cache, unrelated images on this runner, running
-          # containers, and volumes are all left intact.
-          docker images cerebellumnetwork/pos-node -q | sort -u | xargs -r docker rmi -f || true
+          # Self-hosted runner accumulates ${{ env.PACKAGE_NAME }} images
+          # from prior builds and eventually hits "No space left on
+          # device" mid-build. Drop ONLY images tagged under our
+          # repository — buildx cache, unrelated images on this runner,
+          # running containers, and volumes are all left intact.
+          docker images "${{ env.DOCKERHUB_REPOSITORY }}/${{ env.PACKAGE_NAME }}" -q | sort -u | xargs -r docker rmi -f || true
           df -h /
 
       - name: "Checkout code"


### PR DESCRIPTION
## Summary
The build step at the bottom of the workflow references the image as `${{ env.DOCKERHUB_REPOSITORY }}/${{ env.PACKAGE_NAME }}` — single source of truth defined in the `env:` block (currently `cerebellumnetwork/pos-node`). The prune step added in 5f08a715 hardcoded the same string, which would drift on any rename.

This PR makes the prune step use the same `env` vars so changing either field updates both the build and the cleanup at once.

## Test plan
- [x] Local: rendered the workflow expression mentally — `docker images "cerebellumnetwork/pos-node" -q` produces identical output to the prior hardcoded form
- [ ] Next manual build on this branch: verify the prune step name renders correctly and removes only `cerebellumnetwork/pos-node` images