### PR TITLE
ci(manual-build): cap buildx cache instead of pruning host images

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -51,16 +51,19 @@ jobs:
       matrix:
         platform: ${{ fromJSON(needs.prepare.outputs.platforms) }}
     steps:
-      - name: "Prune old ${{ env.PACKAGE_NAME }} images"
+      - name: "Cap buildx cache to free disk"
         run: |
           set -x
           df -h /
-          # Self-hosted runner accumulates ${{ env.PACKAGE_NAME }} images
-          # from prior builds and eventually hits "No space left on
-          # device" mid-build. Drop ONLY images tagged under our
-          # repository — buildx cache, unrelated images on this runner,
-          # running containers, and volumes are all left intact.
-          docker images "${{ env.DOCKERHUB_REPOSITORY }}/${{ env.PACKAGE_NAME }}" -q | sort -u | xargs -r docker rmi -f || true
+          # docker/build-push-action pushes built images directly to the
+          # registry — they're never stored as docker images on the host,
+          # so `docker images ... | xargs rmi` is a no-op. The real
+          # accumulator on a self-hosted runner is the buildx cache,
+          # which grows ~unboundedly across builds (layer reuse).
+          # Cap it at 30 GiB — keeps recent layers for the next build's
+          # fast path, evicts the oldest when the budget is exceeded.
+          docker buildx du || true
+          docker buildx prune --keep-storage 30g --force || true
           df -h /
 
       - name: "Checkout code"


### PR DESCRIPTION
## Summary
PR #716 merged just the env-var refactor; the follow-up commit that actually fixes the disk-fill issue didn't make it in. This PR brings it onto dev.

## Why

The previous cleanup step ran `docker images <repo>/<pkg> | xargs rmi`. **That was a no-op** — `docker/build-push-action` runs builds inside the buildx container and pushes results straight to the registry, so the host docker daemon never tags a local image to remove.

Observed empirically on run 26604351659:

```
+ df -h /
/dev/sda1  150G  124G  21G  86%  /
+ docker images ***/pos-node -q
+ sort -u
+ xargs -r docker rmi -f
+ df -h /
/dev/sda1  150G  124G  21G  86%  /    ← zero bytes reclaimed
```

The real accumulator is the **buildx cache** itself. Cap it at 30 GiB — keeps recent layers for the next build's fast path, evicts the oldest when the budget is exceeded:

```yaml
docker buildx du || true
docker buildx prune --keep-storage 30g --force || true
```

Also runs `docker buildx du` before the prune so future failures have visibility into the cache footprint.

## Test plan
- [x] Next manual build on this branch: prune step logs `docker buildx du` showing actual cache size; `df -h /` post-prune shows reclaimed disk