### PR TITLE
ci(manual-build): bring disk-cleanup fixes onto staging

### DIFF
--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -51,17 +51,34 @@ jobs:
       matrix:
         platform: ${{ fromJSON(needs.prepare.outputs.platforms) }}
     steps:
-      - name: "Prune old pos-node images"
+      - name: "Reclaim disk on self-hosted runner"
         run: |
           set -x
           df -h /
-          # Self-hosted runner accumulates pos-node images from prior
-          # builds and eventually hits "No space left on device"
-          # mid-build. Drop ONLY images tagged under our repository —
-          # buildx cache, unrelated images on this runner, running
-          # containers, and volumes are all left intact.
-          docker images cerebellumnetwork/pos-node -q | sort -u | xargs -r docker rmi -f || true
+          # Print a full breakdown so future failures show exactly
+          # where disk is going.
+          docker system df || true
+          docker volume ls --filter 'name=buildx_buildkit_' || true
+
+          # Drop stopped containers + dangling images + unused networks.
+          docker container prune --force || true
+          docker image prune --force || true
+
+          # Buildkit state volumes from prior `Set up Docker Buildx`
+          # runs accumulate when builders aren't cleanly removed
+          # (post-step skipped on cancelled jobs, etc.). Drop the ones
+          # not currently in use.
+          docker volume ls --filter 'name=buildx_buildkit_' --filter 'dangling=true' -q \
+            | xargs -r docker volume rm || true
+
+          # Across-the-board buildx cache cap (covers any builder still
+          # referenced by another running job).
+          for b in $(docker buildx ls --format '{{.Name}}' 2>/dev/null | tail -n +2 | awk '{print $1}'); do
+            docker buildx prune --builder "$b" --keep-storage 30g --force || true
+          done
+
           df -h /
+          docker system df || true
 
       - name: "Checkout code"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

[blockchain-node#714](https://github.com/Cerebellum-Network/blockchain-node/pull/714) (release/80009 → staging) merged at the first version of the `manual-build` workflow's disk-cleanup step, which turned out to be a no-op. The fixes that actually reclaim disk landed on `release/80009` later as five iterative commits — those are now orphaned because the PR was already closed.

This PR brings the **final** version of `.github/workflows/manual-build.yaml` directly to staging, squashed into one commit.

### What the Reclaim step now does

- Prints `docker system df` and the list of `buildx_buildkit_*` volumes **before AND after** — diagnostic visibility for future failures
- `docker container prune --force` — drops stopped containers (this turned out to be the real disk hog: 36 GiB freed on a runner at 86% usage)
- `docker image prune --force` — drops dangling untagged images
- Removes orphaned buildkit state volumes from prior builder instances
- Iterates every still-existing buildx builder and caps its cache at 30 GiB

Each command is `|| true` so the step never blocks the build on an edge case.

### Observed result

On a fresh build from `release/80009`: 124 GiB → 88 GiB used (reclaimed 36 GiB), build then completed successfully.

## Test plan
- [ ] Next manual build from staging: "Reclaim disk on self-hosted runner" step prints real `docker system df` and the post-prune `df -h /` shows reclaimed disk