### PR TITLE
fix(node): enable RocksDB backend — polkadot-sdk umbrella doesn't forward the feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,6 +2501,7 @@ dependencies = [
  "cere-service",
  "clap",
  "polkadot-sdk",
+ "sc-cli",
  "substrate-build-script-utils",
  "url",
 ]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -27,6 +27,11 @@ url.workspace = true
 
 # Polkadot SDK
 polkadot-sdk = { workspace = true, default-features = true, features = ["frame-benchmarking-cli", "sc-cli", "sc-executor", "sc-network", "sc-service", "sp-io", "sp-runtime"] }
+# Restore sc-cli's default features (which include "rocksdb"). The umbrella
+# pulls sc-cli with default-features off, and the umbrella exposes no
+# passthrough feature for it — matching the pre-umbrella pattern where
+# each consuming crate individually opted into sc-cli's defaults.
+sc-cli = { workspace = true, default-features = true }
 
 # Local
 cere-client = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Working around a gap in the `polkadot-sdk` umbrella crate that PR #725's migration exposed: the umbrella (currently `2512.3.2`) does not expose a `rocksdb` feature that forwards to `sc-cli` / `sc-client-db` / `sc-service`. As a result the built binary silently drops the RocksDB backend — `--database rocksdb` becomes an invalid value, and `--database auto` can't detect existing RocksDB databases on disk (the detection code is `#[cfg(feature = "rocksdb")]`-gated in `sc-cli`).

For mainnet archive nodes with existing RocksDB data going back to genesis, the umbrella-built binary silently falls through to ParityDB, tries to sync from genesis, and crashes on ancient genesis wasm that requires legacy `ext_sandbox_*` host functions.

One-line workaround: declare `sc-cli` as a direct dep in `node/cli/Cargo.toml` alongside the umbrella with `default-features = true`. Cargo unifies features additively, `sc-cli`'s `default = ["rocksdb"]` gets picked up, and the `rocksdb` feature cascades to `sc-client-db/rocksdb` via sc-cli's own feature list. Mirrors the pre-umbrella pattern where each consuming crate opted into individual `sc-*` defaults.

## The upstream gap

Grepped `polkadot-sdk-2512.3.2/Cargo.toml` — no `rocksdb` in the features block. Confirmed against `scripts/generate-umbrella.py` upstream: the features dict has passthroughs for `std`, `runtime-benchmarks`, `try-runtime`, `serde`, `experimental`, `with-tracing`, `tuples-96` — but no `rocksdb`. Zepter therefore doesn't generate `sc-cli?/rocksdb` / `sc-client-db?/rocksdb` / `sc-service?/rocksdb` forwarding lines. Individual crates still ship the feature; the umbrella just doesn't wire it.

Until the umbrella adds a `rocksdb` passthrough (or upstream documents how downstream binaries are supposed to select the RocksDB backend), downstream needs this workaround.

## Verification

Rebuilt `cere` locally from this branch:
```
$ ./target/release/cere --database=rocksdb --version
cere 7.4.0-9de503c6536                              # accepted, no "invalid value"

$ ./target/release/cere --help | grep -A6 -- '--database'
  Possible values:
  - rocksdb:               Facebooks RocksDB       # now listed
  - paritydb:              ParityDb
  - auto:                  Detect whether there is an existing database
  - paritydb-experimental: ParityDb
```

## Test plan

- [ ] CI green on this branch
- [ ] Manual-build produces a mainnet-side v8.4.x image (if release cadence calls for it)
- [ ] Deploy to a mainnet archive node in a maintenance window with `--database auto` — verify it opens the existing RocksDB archive and resumes syncing at the tip block (no genesis resync)

## Companion

Same fix is being applied to staging in #726. This PR ports it to master so the mainnet release cadence isn't gated on staging first.

## Not in this PR

- Filing the upstream issue against `paritytech/polkadot-sdk` — the umbrella is auto-generated (`umbrella/MAINTAIN.md` points at `scripts/generate-umbrella.py`); the fix is trivial (add `"rocksdb": []` to the features dict, let Zepter populate it). Worth filing once we're confident this workaround is stable.
- Removing the workaround: safe to drop this once the umbrella exposes the `rocksdb` feature.