### PR TITLE
chore(deps): bump ddc-{api,dac-host} + pallet-ddc-{verification,payouts} to pick up nodePubKey query-param fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "ddc-api"
 version = "7.3.3"
-source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=dev#1ceb673bebeaed1e449841263f718daedde0d269"
+source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=fix%2Frecords-fetch-node-pubkey#bc8c55b34cc5c5119e09bad60cad73fa0c19f2d3"
 dependencies = [
  "blake2 0.10.6",
  "ddc-primitives",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#69f320b01272e2807dcdf2a4c4206c60e8e5cc7a"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=fix%2Frecords-fetch-node-pubkey#a260bfd1394ac3cd4de2c73fecb7b1a23bc31ebc"
 dependencies = [
  "ddc-api",
  "log",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#c1f65d05a8a4e32a945007f0cb172a38ce823511"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=fix%2Frecords-fetch-node-pubkey#c4e34a89116d0550a2676e5519a959907bf1adb3"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#db402f3e9b5c4158e2cf83e32ffd4dcd81eb939d"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=fix%2Frecords-fetch-node-pubkey#d1c0a6cf5d4dae5de4e89b0015503c55853b29d1"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "ddc-api"
 version = "7.3.3"
-source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=fix%2Frecords-fetch-node-pubkey#bc8c55b34cc5c5119e09bad60cad73fa0c19f2d3"
+source = "git+https://github.com/Cerebellum-Network/ddc-api.git?branch=dev#404139b604d0d04b89fbee94ddfc5eb408d197d0"
 dependencies = [
  "blake2 0.10.6",
  "ddc-primitives",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "ddc-dac-host"
 version = "0.1.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=fix%2Frecords-fetch-node-pubkey#a260bfd1394ac3cd4de2c73fecb7b1a23bc31ebc"
+source = "git+https://github.com/Cerebellum-Network/ddc-dac-host.git?branch=dev#e84b555e594a53492b40930a98a660db1d53c8c8"
 dependencies = [
  "ddc-api",
  "log",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=fix%2Frecords-fetch-node-pubkey#c4e34a89116d0550a2676e5519a959907bf1adb3"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#fed9ca5b7cefefa124dcdbec20633161863617fa"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-verification"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=fix%2Frecords-fetch-node-pubkey#d1c0a6cf5d4dae5de4e89b0015503c55853b29d1"
+source = "git+https://github.com/Cerebellum-Network/ddc-verification.git?branch=dev#a30d1b5522102b967aab1d215cd2170bbe010373"
 dependencies = [
  "array-bytes 6.2.3",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,10 +203,10 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
-ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
+ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
 
 # Hyperbridge (polkadot-stable2512). Only these four pallets are wired into the
 # runtime; `ismp` and `pallet-ismp-runtime-api` are required transitively to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,10 +203,10 @@ pallet-fee-handler = { path = "pallets/fee-handler", default-features = false }
 
 # Cere External Dependencies
 ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
-ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "dev", default-features = false }
-ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "dev", default-features = false }
-pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "dev", default-features = false }
-pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "dev", default-features = false }
+ddc-api = { git = "https://github.com/Cerebellum-Network/ddc-api.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
+ddc-dac-host = { git = "https://github.com/Cerebellum-Network/ddc-dac-host.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
+pallet-ddc-verification = { git = "https://github.com/Cerebellum-Network/ddc-verification.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
+pallet-ddc-payouts = { git = "https://github.com/Cerebellum-Network/ddc-payouts.git", branch = "fix/records-fetch-node-pubkey", default-features = false }
 
 # Hyperbridge (polkadot-stable2512). Only these four pallets are wired into the
 # runtime; `ismp` and `pallet-ismp-runtime-api` are required transitively to

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80011,
+	spec_version: 80012,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80011,
+	spec_version: 80012,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,


### PR DESCRIPTION
Lockfile-only bump. Picks up ddc-api's [PR #47](https://github.com/Cerebellum-Network/ddc-api/pull/47) transitively. cere-runtime rebuilt clean in release mode (~20 min). No code changes.