### PR TITLE
runtime: bump spec_version to 80013

### DIFF
--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80012,
+	spec_version: 80013,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80012,
+	spec_version: 80013,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,


### PR DESCRIPTION
## Summary

Bumps `spec_version` **80012 → 80013** on both `cere` and `cere-dev` runtimes.

## Why

The recent ddc-{api,dac-host} + pallet-ddc-{verification,payouts} lockfile bump (#728) changes the runtime WASM — `ddc-api` is in the runtime dependency closure (via `ddc-dac-host` and both pallets), and its `fetch_records_range` now sends the required `nodePubKey` query param. That merged with `spec_version = 80012`, but **live devnet is already running 80012** (different code hash), so it can't be applied as an upgrade:

```
try-runtime: New runtime spec version must be greater than the on-chain
runtime spec version: 80012 <= 80012
```

Bumping to 80013 lets the change deploy as a real runtime upgrade.

## What changed

- `runtime/cere/src/lib.rs`: `spec_version` 80012 → 80013
- `runtime/cere-dev/src/lib.rs`: `spec_version` 80012 → 80013

`transaction_version` stays at **27** (no extrinsic / signed-extension changes) and `Migrations` stays `()` (OCW-only change — no storage layout change, nothing to add or remove).

## try-runtime verification (cere-dev vs `wss://archive.devnet.cere.network`)

`on-runtime-upgrade --checks=all`:

- ✅ `on_runtime_upgrade` succeeded; migrations idempotent (storage root unchanged)
- ✅ PoV 11.5 KB; weight 0.0015s = **0.08%** of the 2s block budget; no weight safety issues
- ✅ Entire post-upgrade state decodes without error (4.9 MB total)

Pre-existing, unrelated finding (NOT introduced here): the Staking `try_state` invariant `MaxValidatorSet (1000) >= MaxWinnersPerPage (1200)` is violated in the cere-dev config. It only surfaces under `--checks=all` try-state and does not affect the upgrade itself — tracked for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)