### PR TITLE
CERE/USD price oracle on chain

### DIFF
--- a/.github/workflows/build-cache-config.yaml
+++ b/.github/workflows/build-cache-config.yaml
@@ -34,6 +34,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Configure AWS credentials (for ECR only)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -41,6 +43,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -70,6 +74,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain and rust-src
@@ -102,6 +108,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain and rust-src
@@ -135,6 +143,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain
@@ -164,6 +174,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler make pkg-config
       - name: Install toolchain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,9 @@ jobs:
         with:
           submodules: true
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
           components: rustfmt
       - name: Check TOML
         uses: dprint/check@v2.2
@@ -46,10 +45,9 @@ jobs:
         with:
           submodules: true
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Configure Git
@@ -79,11 +77,10 @@ jobs:
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain and rust-src
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: rust-src
       - name: Enhanced Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -113,11 +110,10 @@ jobs:
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain and rust-src
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: rust-src
       - name: Enhanced Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -148,11 +144,10 @@ jobs:
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: rust-src
       - name: Enhanced Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -184,11 +179,10 @@ jobs:
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler make pkg-config
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.91.0
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: rust-src
       - name: Configure Git
         run: git config --global url."https://${{ secrets.GH_READ_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,8 +163,13 @@ jobs:
         run: git config --global url."https://${{ secrets.GH_READ_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
       - name: Check with Clippy (Optimized)
         run: |
-          # Run clippy with incremental compilation
-          CARGO_INCREMENTAL=1 cargo clippy --no-deps --all-targets --features runtime-benchmarks,try-runtime --workspace -- --deny warnings
+          # Run clippy with incremental compilation.
+          # The orml crates under third_party/ are workspace members so their
+          # `{ workspace = true }` deps resolve, but they are vendored upstream
+          # code and are not held to this repo's lint policy.
+          CARGO_INCREMENTAL=1 cargo clippy --no-deps --all-targets --features runtime-benchmarks,try-runtime --workspace \
+            --exclude orml-oracle --exclude orml-traits --exclude orml-utilities \
+            -- --deny warnings
 
   tests:
     name: Run tests
@@ -199,6 +204,7 @@ jobs:
       - name: Run cargo-tarpaulin
         run: |
           cargo tarpaulin --verbose --locked --no-fail-fast --workspace \
+            --exclude orml-oracle --exclude orml-traits --exclude orml-utilities \
             --features runtime-benchmarks --out "Xml" -- \
             --skip mock_clusters_gov::__construct_runtime_integrity_test::runtime_integrity_tests \
             --skip tests::call_size

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,12 @@ jobs:
     needs: format
     # The type of runner that the job will run on
     runs-on: ["self-hosted", "cere-network-memory-large"]
+    # This runner does not set HOME, so `git config --global` fails with
+    # "fatal: $HOME not set". CARGO_HOME is already pinned on the runner for
+    # the same reason; point HOME at the per-job temp dir so git has a
+    # writable global config without guessing the runner's user.
+    env:
+      HOME: ${{ runner.temp }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,17 +171,21 @@ jobs:
     needs: format
     # The type of runner that the job will run on
     runs-on: ["self-hosted", "cere-network-memory-large"]
-    # This runner does not set HOME, so `git config --global` fails with
-    # "fatal: $HOME not set". CARGO_HOME is already pinned on the runner for
-    # the same reason; point HOME at the per-job temp dir so git has a
-    # writable global config without guessing the runner's user.
-    env:
-      HOME: ${{ runner.temp }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
           submodules: true
+      # This runner does not set HOME, so `git config --global` fails with
+      # "fatal: $HOME not set". CARGO_HOME is already pinned on the runner for
+      # the same reason. Export a writable HOME to every later step rather than
+      # guessing the runner's user. Set here, after checkout, because checkout
+      # manages HOME itself.
+      - name: Ensure HOME is set
+        run: |
+          if [ -z "${HOME:-}" ]; then
+            echo "HOME=${RUNNER_TEMP}" >> "$GITHUB_ENV"
+          fi
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler make pkg-config
       - name: Install toolchain

--- a/.github/workflows/generate_weights.yml
+++ b/.github/workflows/generate_weights.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Install hcloud CLI
         run: |

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -82,6 +82,8 @@ jobs:
 
       - name: "Checkout code"
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: "Configure Git"
         run: git config --global url."https://${{ secrets.GH_READ_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 0
 
       - name: Set up Python
@@ -54,6 +55,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -104,6 +107,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -20,6 +20,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Configure Git
         run: git config --global url."https://${{ secrets.GH_READ_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/try-runtime-local.yaml
+++ b/.github/workflows/try-runtime-local.yaml
@@ -14,6 +14,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install linux dependencies
         run: sudo apt update && sudo apt install -y cargo clang libssl-dev llvm libudev-dev protobuf-compiler
       - name: Install toolchain and rust-src

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "orml"]
-	path = orml
+[submodule "third_party/open-runtime-module-library"]
+	path = third_party/open-runtime-module-library
 	url = https://github.com/open-web3-stack/open-runtime-module-library.git
 	branch = polkadot-stable2512

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "orml"]
+	path = orml
+	url = https://github.com/open-web3-stack/open-runtime-module-library.git
+	branch = polkadot-stable2512

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,7 @@ dependencies = [
  "ismp",
  "ismp-grandpa",
  "log",
+ "orml-oracle",
  "pallet-chainbridge",
  "pallet-ddc-clusters",
  "pallet-ddc-clusters-gov",
@@ -9383,6 +9384,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "orml-oracle"
+version = "1.5.0"
+source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "orml-utilities",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-traits"
+version = "1.5.0"
+source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples",
+ "num-traits",
+ "orml-utilities",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm 21.0.0",
+]
+
+[[package]]
+name = "orml-utilities"
+version = "1.5.0"
+source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9389,7 +9389,6 @@ dependencies = [
 [[package]]
 name = "orml-oracle"
 version = "1.5.0"
-source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9400,6 +9399,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -9408,7 +9408,6 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "1.5.0"
-source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -9428,9 +9427,9 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "1.5.0"
-source = "git+https://github.com/yahortsaryk/open-runtime-module-library?branch=cere%2Fpolkadot-stable2512#32034ababba8ca9bd129fd090e30a391a82b5275"
 dependencies = [
  "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,13 @@ members = [
   "runtime/cere",
   "runtime/cere-dev",
   "contracts/customer-deposit",
+  # orml git submodule. Upstream ships no root Cargo.toml by design, so its
+  # crates inherit their dependencies from whichever workspace embeds them.
+  # This is the integration path orml's maintainers recommend (Acala does the
+  # same) -- see open-web3-stack/open-runtime-module-library#980 and #1000.
+  "orml/oracle",
+  "orml/traits",
+  "orml/utilities",
 ]
 resolver = "2"
 
@@ -48,7 +55,15 @@ hex-literal = { version = "^0.4.1", default-features = false }
 jsonrpsee = { version = "0.24.3", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5.0", default-features = false }
 log = { version = "0.4.22", default-features = false }
-orml-oracle = { git = "https://github.com/yahortsaryk/open-runtime-module-library", branch = "cere/polkadot-stable2512", default-features = false }
+orml-oracle = { path = "orml/oracle", default-features = false }
+# Names the orml submodule crates inherit from this workspace but that nothing
+# else here declares. The frame/sp pins they need already exist below at
+# matching versions.
+impl-trait-for-tuples = "0.2.2"
+num-traits = { version = "0.2.14", default-features = false }
+parity-scale-codec = { version = "3.7.5", default-features = false, features = ["derive", "max-encoded-len"] }
+paste = "1.0"
+xcm = { version = "21.0.0", package = "staging-xcm", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 polkadot-ckb-merkle-mountain-range = { version = "0.8.1", default-features = false }
 prost = { version = "0.12.4", default-features = false, features = ["prost-derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ members = [
   # crates inherit their dependencies from whichever workspace embeds them.
   # This is the integration path orml's maintainers recommend (Acala does the
   # same) -- see open-web3-stack/open-runtime-module-library#980 and #1000.
-  "orml/oracle",
-  "orml/traits",
-  "orml/utilities",
+  "third_party/open-runtime-module-library/oracle",
+  "third_party/open-runtime-module-library/traits",
+  "third_party/open-runtime-module-library/utilities",
 ]
 resolver = "2"
 
@@ -55,7 +55,7 @@ hex-literal = { version = "^0.4.1", default-features = false }
 jsonrpsee = { version = "0.24.3", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5.0", default-features = false }
 log = { version = "0.4.22", default-features = false }
-orml-oracle = { path = "orml/oracle", default-features = false }
+orml-oracle = { path = "third_party/open-runtime-module-library/oracle", default-features = false }
 # Names the orml submodule crates inherit from this workspace but that nothing
 # else here declares. The frame/sp pins they need already exist below at
 # matching versions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ hex-literal = { version = "^0.4.1", default-features = false }
 jsonrpsee = { version = "0.24.3", default-features = false, features = ["server"] }
 lazy_static = { version = "1.5.0", default-features = false }
 log = { version = "0.4.22", default-features = false }
+orml-oracle = { git = "https://github.com/yahortsaryk/open-runtime-module-library", branch = "cere/polkadot-stable2512", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 polkadot-ckb-merkle-mountain-range = { version = "0.8.1", default-features = false }
 prost = { version = "0.12.4", default-features = false, features = ["prost-derive"] }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ First, complete the [basic Rust setup instructions](./docs/rust-setup.md).
 ./scripts/init.sh
 ```
 
+This also initializes the `third_party/` submodules. The orml submodule is
+sparse-checked-out to the three crates this workspace builds (`oracle`,
+`traits`, `utilities`) rather than all ~24 of its pallets. Re-run
+`./scripts/init-submodules.sh` if a `git submodule` command resets its
+working tree.
+
 ### Build
 
 Use the following command to build the node without launching it:

--- a/dprint.json
+++ b/dprint.json
@@ -1,5 +1,5 @@
 {
   "includes": ["**/*.{toml}"],
-  "excludes": ["**/target"],
+  "excludes": ["**/target", "third_party"],
   "plugins": ["https://plugins.dprint.dev/toml-0.5.3.wasm"]
 }

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -85,6 +85,7 @@ std = [
   "pallet-hyper-fungible-token/std",
 ]
 runtime-benchmarks = [
+  "orml-oracle/runtime-benchmarks",
   "polkadot-sdk/frame-benchmarking",
   "polkadot-sdk/frame-system-benchmarking",
   "polkadot-sdk/pallet-election-provider-support-benchmarking",
@@ -108,6 +109,7 @@ runtime-benchmarks = [
   "pallet-hyper-fungible-token/runtime-benchmarks",
 ]
 try-runtime = [
+  "orml-oracle/try-runtime",
   "polkadot-sdk/frame-try-runtime",
   "polkadot-sdk/try-runtime",
   "pallet-chainbridge/try-runtime",

--- a/runtime/cere-dev/Cargo.toml
+++ b/runtime/cere-dev/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 hex-literal = { workspace = true, default-features = true, optional = true }
 log.workspace = true
+orml-oracle = { workspace = true }
 scale-info.workspace = true
 static_assertions.workspace = true
 
@@ -58,6 +59,7 @@ std = [
   "codec/std",
   "scale-info/std",
   "log/std",
+  "orml-oracle/std",
   "polkadot-sdk/std",
   "ddc-primitives/std",
   "pallet-chainbridge/std",

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80013,
+	spec_version: 80014,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1680,20 +1680,44 @@ impl polkadot_sdk::frame_support::traits::SortedMembers<AccountId> for PriceOrac
 	fn add(_who: &AccountId) {}
 }
 
+/// Key space of the price oracle. A typed key rather than a bare integer so a
+/// second pair can be added later without reinterpreting existing storage.
+#[derive(
+	Clone,
+	Copy,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Debug,
+	codec::Encode,
+	codec::Decode,
+	codec::DecodeWithMemTracking,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+)]
+pub enum PriceKey {
+	/// USD per CERE, scaled by 10^18 (atto-USD per CERE).
+	CereUsd,
+}
+
 impl orml_oracle::Config for Runtime {
 	type OnNewData = ();
-	// Median over unexpired operator submissions, falling back to the previous value
-	// when fewer than 3 operators are fresh within the last hour.
+	// Median over unexpired operator submissions. Below MinimumCount fresh
+	// values the previous median is kept rather than stalling. ADR-001:
+	// MinimumCount = 2 of 3 operators, ExpiresIn = 3h.
 	type CombineData =
-		orml_oracle::DefaultCombineData<Runtime, ConstU32<3>, ConstU64<3_600_000>, ()>;
+		orml_oracle::DefaultCombineData<Runtime, ConstU32<2>, ConstU64<10_800_000>, ()>;
 	type Time = Timestamp;
-	type OracleKey = u8;
+	type OracleKey = PriceKey;
 	type OracleValue = u128;
 	type RootOperatorAccountId = PriceOracleRootOperator;
 	type Members = PriceOracleOperators;
 	type WeightInfo = ();
-	type MaxHasDispatchedSize = ConstU32<40>;
-	type MaxFeedValues = ConstU32<4>;
+	// Three operators plus the root operator, with headroom.
+	type MaxHasDispatchedSize = ConstU32<8>;
+	// One key, so one pair per submission.
+	type MaxFeedValues = ConstU32<1>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1723,7 +1723,9 @@ impl orml_oracle::Config for Runtime {
 	type OracleValue = u128;
 	type RootOperatorAccountId = PriceOracleRootOperator;
 	type Members = PriceOracleMembership;
-	type WeightInfo = ();
+	// Provisional, not benchmarked — see the module header. Upstream's default
+	// impl is non-zero but was benchmarked on 2021 Acala hardware.
+	type WeightInfo = weights::orml_oracle::WeightInfo<Runtime>;
 	// Three operators plus the root operator, with headroom.
 	type MaxHasDispatchedSize = ConstU32<8>;
 	// One key, so one pair per submission.
@@ -1922,8 +1924,7 @@ mod runtime {
 	pub type PriceOracle = orml_oracle::Pallet<Runtime>;
 
 	#[runtime::pallet_index(56)]
-	pub type PriceOracleMembership =
-		polkadot_sdk::pallet_membership::Pallet<Runtime, Instance4>;
+	pub type PriceOracleMembership = polkadot_sdk::pallet_membership::Pallet<Runtime, Instance4>;
 }
 
 /// The address format for describing accounts.
@@ -1989,6 +1990,8 @@ type EventRecord = polkadot_sdk::frame_system::EventRecord<
 mod benches {
 	polkadot_sdk::frame_benchmarking::define_benchmarks!(
 		[frame_benchmarking, BaselineBench::<Runtime>]
+		[orml_oracle, PriceOracle]
+		[pallet_membership, PriceOracleMembership]
 		[pallet_babe, Babe]
 		[pallet_bags_list, VoterList]
 		[pallet_balances, Balances]

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1661,23 +1661,33 @@ parameter_types! {
 	pub PriceOracleRootOperator: AccountId = PriceOraclePalletId::get().into_account_truncating();
 }
 
-/// Governance-curated set of CERE/USD price feed operators.
+/// Membership instance holding the price-oracle operator set. Governance adds
+/// and removes feeders here; ADR-001 §2 makes that the path to decentralising
+/// the feed without a runtime upgrade.
 ///
-/// SPIKE: empty set. Real wiring points this at a `pallet_membership` instance so
-/// governance can add and remove feeders without a runtime upgrade.
-pub struct PriceOracleOperators;
-impl polkadot_sdk::frame_support::traits::SortedMembers<AccountId> for PriceOracleOperators {
-	fn sorted_members() -> polkadot_sdk::sp_std::vec::Vec<AccountId> {
-		polkadot_sdk::sp_std::vec::Vec::new()
-	}
-	fn contains(_who: &AccountId) -> bool {
-		false
-	}
-	fn count() -> usize {
-		0
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn add(_who: &AccountId) {}
+/// Instance markers are scoped to a single pallet, so any of them would be
+/// technically safe. `Instance4` is picked so the markers used in this runtime
+/// stay unique as a set — `Instance1` is `VoterList` (bags-list) and
+/// `Instance3` is `TechComm` (collective) — and a reader does not have to know
+/// the scoping rule to see that nothing is shared.
+pub type PriceOracleMembershipInstance = polkadot_sdk::pallet_membership::Instance4;
+
+impl polkadot_sdk::pallet_membership::Config<PriceOracleMembershipInstance> for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type AddOrigin = EnsureRoot<AccountId>;
+	type RemoveOrigin = EnsureRoot<AccountId>;
+	type SwapOrigin = EnsureRoot<AccountId>;
+	type ResetOrigin = EnsureRoot<AccountId>;
+	type PrimeOrigin = EnsureRoot<AccountId>;
+	// orml-oracle implements ChangeMembers but not InitializeMembers, so only
+	// the change hook is wired. That is the one that matters: it prunes a
+	// removed operator's submitted value. Authorisation itself reads the
+	// membership set live through `Members`, and no members are seeded at
+	// genesis (ADR-001 §2 puts the set under governance).
+	type MembershipInitialized = ();
+	type MembershipChanged = PriceOracle;
+	type MaxMembers = ConstU32<16>;
+	type WeightInfo = polkadot_sdk::pallet_membership::weights::SubstrateWeight<Runtime>;
 }
 
 /// Key space of the price oracle. A typed key rather than a bare integer so a
@@ -1712,7 +1722,7 @@ impl orml_oracle::Config for Runtime {
 	type OracleKey = PriceKey;
 	type OracleValue = u128;
 	type RootOperatorAccountId = PriceOracleRootOperator;
-	type Members = PriceOracleOperators;
+	type Members = PriceOracleMembership;
 	type WeightInfo = ();
 	// Three operators plus the root operator, with headroom.
 	type MaxHasDispatchedSize = ConstU32<8>;
@@ -1910,6 +1920,10 @@ mod runtime {
 
 	#[runtime::pallet_index(55)]
 	pub type PriceOracle = orml_oracle::Pallet<Runtime>;
+
+	#[runtime::pallet_index(56)]
+	pub type PriceOracleMembership =
+		polkadot_sdk::pallet_membership::Pallet<Runtime, Instance4>;
 }
 
 /// The address format for describing accounts.

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1656,6 +1656,48 @@ impl pallet_pool_withdrawal_fix::Config for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const PriceOraclePalletId: PalletId = PalletId(*b"cereorcl");
+	pub PriceOracleRootOperator: AccountId = PriceOraclePalletId::get().into_account_truncating();
+}
+
+/// Governance-curated set of CERE/USD price feed operators.
+///
+/// SPIKE: empty set. Real wiring points this at a `pallet_membership` instance so
+/// governance can add and remove feeders without a runtime upgrade.
+pub struct PriceOracleOperators;
+impl polkadot_sdk::frame_support::traits::SortedMembers<AccountId> for PriceOracleOperators {
+	fn sorted_members() -> polkadot_sdk::sp_std::vec::Vec<AccountId> {
+		polkadot_sdk::sp_std::vec::Vec::new()
+	}
+	fn contains(_who: &AccountId) -> bool {
+		false
+	}
+	fn count() -> usize {
+		0
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn add(_who: &AccountId) {}
+}
+
+impl orml_oracle::Config for Runtime {
+	type OnNewData = ();
+	// Median over unexpired operator submissions, falling back to the previous value
+	// when fewer than 3 operators are fresh within the last hour.
+	type CombineData =
+		orml_oracle::DefaultCombineData<Runtime, ConstU32<3>, ConstU64<3_600_000>, ()>;
+	type Time = Timestamp;
+	type OracleKey = u8;
+	type OracleValue = u128;
+	type RootOperatorAccountId = PriceOracleRootOperator;
+	type Members = PriceOracleOperators;
+	type WeightInfo = ();
+	type MaxHasDispatchedSize = ConstU32<40>;
+	type MaxFeedValues = ConstU32<4>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
+}
+
 #[polkadot_sdk::frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -1841,6 +1883,9 @@ mod runtime {
 
 	#[runtime::pallet_index(54)]
 	pub type PoolWithdrawalFix = pallet_pool_withdrawal_fix::Pallet<Runtime>;
+
+	#[runtime::pallet_index(55)]
+	pub type PriceOracle = orml_oracle::Pallet<Runtime>;
 }
 
 /// The address format for describing accounts.

--- a/runtime/cere-dev/src/weights/mod.rs
+++ b/runtime/cere-dev/src/weights/mod.rs
@@ -1,3 +1,4 @@
 pub mod ismp_grandpa;
+pub mod orml_oracle;
 pub mod pallet_balances_balances;
 pub mod pallet_ismp;

--- a/runtime/cere-dev/src/weights/orml_oracle.rs
+++ b/runtime/cere-dev/src/weights/orml_oracle.rs
@@ -1,0 +1,52 @@
+//! Provisional weights for `orml_oracle`.
+//!
+//! These are **not** benchmarked. They are hand-set, deliberately conservative
+//! estimates so the pallet does not run on upstream's defaults, which were
+//! benchmarked on Acala hardware in 2021.
+//!
+//! The storage access counts are read off the extrinsic rather than guessed:
+//! `feed_values` reads the membership set and `HasDispatched`, writes
+//! `HasDispatched`, and for each fed value reads the key's `RawValues` (to
+//! combine) and writes both `RawValues` and `Values`. `on_finalize` clears
+//! `HasDispatched`.
+//!
+//! Regenerate with the benchmark CLI before mainnet:
+//!
+//! ```text
+//! cere benchmark pallet --chain=dev --pallet=orml_oracle --extrinsic='*' \
+//!   --wasm-execution=compiled --steps=50 --repeat=20 \
+//!   --output=runtime/cere-dev/src/weights/orml_oracle.rs
+//! ```
+
+#![allow(unused_parens)]
+#![allow(clippy::unnecessary_cast)]
+
+use core::marker::PhantomData;
+use polkadot_sdk::frame_support::{traits::Get, weights::Weight};
+
+/// Provisional weights for `orml_oracle`, parameterised by the runtime's
+/// configured DB weights.
+pub struct WeightInfo<T>(PhantomData<T>);
+
+impl<T: polkadot_sdk::frame_system::Config> orml_oracle::WeightInfo for WeightInfo<T> {
+	/// `c` is the number of values fed in one call, bounded by `MaxFeedValues`.
+	fn feed_values(c: u32) -> Weight {
+		// Roughly 2.5x upstream's 2021 base to stay conservative on unknown
+		// validator hardware; over-estimating costs block space, under-
+		// estimating is a liveness risk.
+		Weight::from_parts(40_000_000, 0)
+			.saturating_add(Weight::from_parts(10_000_000, 0).saturating_mul(c as u64))
+			// membership set + HasDispatched + the previous aggregate
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			// one RawValues read per fed key, to recombine
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c as u64)))
+			// HasDispatched
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+			// RawValues + Values per fed key
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(c as u64)))
+	}
+
+	fn on_finalize() -> Weight {
+		Weight::from_parts(10_000_000, 0).saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+}

--- a/runtime/cere/Cargo.toml
+++ b/runtime/cere/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 hex-literal = { workspace = true, default-features = true, optional = true }
 log.workspace = true
+orml-oracle = { workspace = true }
 scale-info.workspace = true
 static_assertions.workspace = true
 
@@ -58,6 +59,7 @@ std = [
   "codec/std",
   "scale-info/std",
   "log/std",
+  "orml-oracle/std",
   "polkadot-sdk/std",
   "pallet-chainbridge/std",
   "pallet-erc721/std",
@@ -82,6 +84,7 @@ std = [
   "pallet-hyper-fungible-token/std",
 ]
 runtime-benchmarks = [
+  "orml-oracle/runtime-benchmarks",
   "polkadot-sdk/frame-benchmarking",
   "polkadot-sdk/frame-system-benchmarking",
   "polkadot-sdk/pallet-election-provider-support-benchmarking",
@@ -105,6 +108,7 @@ runtime-benchmarks = [
   "pallet-hyper-fungible-token/runtime-benchmarks",
 ]
 try-runtime = [
+  "orml-oracle/try-runtime",
   "polkadot-sdk/frame-try-runtime",
   "polkadot-sdk/try-runtime",
   "pallet-chainbridge/try-runtime",

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80013,
+	spec_version: 80014,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1643,6 +1643,84 @@ impl pallet_pool_withdrawal_fix::Config for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const PriceOraclePalletId: PalletId = PalletId(*b"cereorcl");
+	pub PriceOracleRootOperator: AccountId = PriceOraclePalletId::get().into_account_truncating();
+}
+
+/// Membership instance holding the price-oracle operator set. Governance adds
+/// and removes feeders here; ADR-001 §2 makes that the path to decentralising
+/// the feed without a runtime upgrade.
+///
+/// Instance markers are scoped to a single pallet, so any of them would be
+/// technically safe. `Instance4` is picked so the markers used in this runtime
+/// stay unique as a set — `Instance1` is `VoterList` (bags-list) and
+/// `Instance3` is `TechComm` (collective) — and a reader does not have to know
+/// the scoping rule to see that nothing is shared.
+pub type PriceOracleMembershipInstance = polkadot_sdk::pallet_membership::Instance4;
+
+impl polkadot_sdk::pallet_membership::Config<PriceOracleMembershipInstance> for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type AddOrigin = EnsureRoot<AccountId>;
+	type RemoveOrigin = EnsureRoot<AccountId>;
+	type SwapOrigin = EnsureRoot<AccountId>;
+	type ResetOrigin = EnsureRoot<AccountId>;
+	type PrimeOrigin = EnsureRoot<AccountId>;
+	// orml-oracle implements ChangeMembers but not InitializeMembers, so only
+	// the change hook is wired. That is the one that matters: it prunes a
+	// removed operator's submitted value. Authorisation itself reads the
+	// membership set live through `Members`, and no members are seeded at
+	// genesis (ADR-001 §2 puts the set under governance).
+	type MembershipInitialized = ();
+	type MembershipChanged = PriceOracle;
+	type MaxMembers = ConstU32<16>;
+	type WeightInfo = polkadot_sdk::pallet_membership::weights::SubstrateWeight<Runtime>;
+}
+
+/// Key space of the price oracle. A typed key rather than a bare integer so a
+/// second pair can be added later without reinterpreting existing storage.
+#[derive(
+	Clone,
+	Copy,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Debug,
+	codec::Encode,
+	codec::Decode,
+	codec::DecodeWithMemTracking,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+)]
+pub enum PriceKey {
+	/// USD per CERE, scaled by 10^18 (atto-USD per CERE).
+	CereUsd,
+}
+
+impl orml_oracle::Config for Runtime {
+	type OnNewData = ();
+	// Median over unexpired operator submissions. Below MinimumCount fresh
+	// values the previous median is kept rather than stalling. ADR-001:
+	// MinimumCount = 2 of 3 operators, ExpiresIn = 3h.
+	type CombineData =
+		orml_oracle::DefaultCombineData<Runtime, ConstU32<2>, ConstU64<10_800_000>, ()>;
+	type Time = Timestamp;
+	type OracleKey = PriceKey;
+	type OracleValue = u128;
+	type RootOperatorAccountId = PriceOracleRootOperator;
+	type Members = PriceOracleMembership;
+	// Provisional, not benchmarked — see the module header. Upstream's default
+	// impl is non-zero but was benchmarked on 2021 Acala hardware.
+	type WeightInfo = weights::orml_oracle::WeightInfo<Runtime>;
+	// Three operators plus the root operator, with headroom.
+	type MaxHasDispatchedSize = ConstU32<8>;
+	// One key, so one pair per submission.
+	type MaxFeedValues = ConstU32<1>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
+}
+
 #[polkadot_sdk::frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -1827,6 +1905,12 @@ mod runtime {
 
 	#[runtime::pallet_index(54)]
 	pub type PoolWithdrawalFix = pallet_pool_withdrawal_fix::Pallet<Runtime>;
+
+	#[runtime::pallet_index(55)]
+	pub type PriceOracle = orml_oracle::Pallet<Runtime>;
+
+	#[runtime::pallet_index(56)]
+	pub type PriceOracleMembership = polkadot_sdk::pallet_membership::Pallet<Runtime, Instance4>;
 }
 
 /// The address format for describing accounts.
@@ -1946,6 +2030,8 @@ type EventRecord = polkadot_sdk::frame_system::EventRecord<
 mod benches {
 	polkadot_sdk::frame_benchmarking::define_benchmarks!(
 		[frame_benchmarking, BaselineBench::<Runtime>]
+		[orml_oracle, PriceOracle]
+		[pallet_membership, PriceOracleMembership]
 		[pallet_babe, Babe]
 		[pallet_bags_list, VoterList]
 		[pallet_balances, Balances]

--- a/runtime/cere/src/weights/mod.rs
+++ b/runtime/cere/src/weights/mod.rs
@@ -1,3 +1,4 @@
 pub mod ismp_grandpa;
+pub mod orml_oracle;
 pub mod pallet_balances_balances;
 pub mod pallet_ismp;

--- a/runtime/cere/src/weights/orml_oracle.rs
+++ b/runtime/cere/src/weights/orml_oracle.rs
@@ -1,0 +1,52 @@
+//! Provisional weights for `orml_oracle`.
+//!
+//! These are **not** benchmarked. They are hand-set, deliberately conservative
+//! estimates so the pallet does not run on upstream's defaults, which were
+//! benchmarked on Acala hardware in 2021.
+//!
+//! The storage access counts are read off the extrinsic rather than guessed:
+//! `feed_values` reads the membership set and `HasDispatched`, writes
+//! `HasDispatched`, and for each fed value reads the key's `RawValues` (to
+//! combine) and writes both `RawValues` and `Values`. `on_finalize` clears
+//! `HasDispatched`.
+//!
+//! Regenerate with the benchmark CLI before mainnet:
+//!
+//! ```text
+//! cere benchmark pallet --chain=dev --pallet=orml_oracle --extrinsic='*' \
+//!   --wasm-execution=compiled --steps=50 --repeat=20 \
+//!   --output=runtime/cere-dev/src/weights/orml_oracle.rs
+//! ```
+
+#![allow(unused_parens)]
+#![allow(clippy::unnecessary_cast)]
+
+use core::marker::PhantomData;
+use polkadot_sdk::frame_support::{traits::Get, weights::Weight};
+
+/// Provisional weights for `orml_oracle`, parameterised by the runtime's
+/// configured DB weights.
+pub struct WeightInfo<T>(PhantomData<T>);
+
+impl<T: polkadot_sdk::frame_system::Config> orml_oracle::WeightInfo for WeightInfo<T> {
+	/// `c` is the number of values fed in one call, bounded by `MaxFeedValues`.
+	fn feed_values(c: u32) -> Weight {
+		// Roughly 2.5x upstream's 2021 base to stay conservative on unknown
+		// validator hardware; over-estimating costs block space, under-
+		// estimating is a liveness risk.
+		Weight::from_parts(40_000_000, 0)
+			.saturating_add(Weight::from_parts(10_000_000, 0).saturating_mul(c as u64))
+			// membership set + HasDispatched + the previous aggregate
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			// one RawValues read per fed key, to recombine
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c as u64)))
+			// HasDispatched
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+			// RawValues + Values per fed key
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(c as u64)))
+	}
+
+	fn on_finalize() -> Weight {
+		Weight::from_parts(10_000_000, 0).saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+}

--- a/scripts/init-submodules.sh
+++ b/scripts/init-submodules.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Initializes third_party submodules, checking out only the parts this
+# workspace actually builds.
+#
+# The orml repository holds ~24 pallets but we only use three of them
+# (oracle, plus traits and utilities which oracle path-depends on). Sparse
+# checkout keeps the rest off disk: 1.4M -> 228K.
+#
+# Sparse-checkout settings live in .git/ and are not committed, so this has
+# to be run once per clone. CI does a plain full submodule checkout instead —
+# the extra megabyte is not worth another moving part in the pipeline.
+
+ORML_PATH="third_party/open-runtime-module-library"
+
+echo "*** Initializing submodules"
+git submodule update --init --recursive
+
+echo "*** Trimming ${ORML_PATH} to the crates this workspace builds"
+git -C "${ORML_PATH}" sparse-checkout init --cone
+git -C "${ORML_PATH}" sparse-checkout set oracle traits utilities
+
+echo "*** Done"
+git -C "${ORML_PATH}" sparse-checkout list

--- a/scripts/init-submodules.sh
+++ b/scripts/init-submodules.sh
@@ -5,22 +5,31 @@ set -e
 # Initializes third_party submodules, checking out only the parts this
 # workspace actually builds.
 #
-# The orml repository holds ~24 pallets but we only use three of them
-# (oracle, plus traits and utilities which oracle path-depends on). Sparse
-# checkout keeps the rest off disk: 1.4M -> 228K.
+# The orml repository holds ~24 pallets; we build three of them -- oracle,
+# plus traits and utilities, which oracle path-depends on. Sparse checkout
+# keeps the other 21 off disk (1.4M -> 228K) so third_party/ shows only what
+# this chain uses.
 #
-# Sparse-checkout settings live in .git/ and are not committed, so this has
-# to be run once per clone. CI does a plain full submodule checkout instead —
-# the extra megabyte is not worth another moving part in the pipeline.
+# Sparse-checkout settings live in .git/ and are not committed, so this runs
+# per clone. It is invoked from scripts/init.sh; run it directly after a
+# `git submodule` command that resets the working tree.
+#
+# CI does a plain full submodule checkout instead (submodules: true on the
+# actions/checkout steps) -- one extra megabyte is not worth another moving
+# part in the pipeline.
 
 ORML_PATH="third_party/open-runtime-module-library"
 
 echo "*** Initializing submodules"
 git submodule update --init --recursive
 
-echo "*** Trimming ${ORML_PATH} to the crates this workspace builds"
-git -C "${ORML_PATH}" sparse-checkout init --cone
-git -C "${ORML_PATH}" sparse-checkout set oracle traits utilities
-
-echo "*** Done"
-git -C "${ORML_PATH}" sparse-checkout list
+# sparse-checkout needs git >= 2.25. Trimming is a convenience, never a
+# correctness requirement, so fall back to the full checkout if unsupported.
+if git -C "${ORML_PATH}" sparse-checkout init --cone 2>/dev/null; then
+  echo "*** Trimming ${ORML_PATH} to the crates this workspace builds"
+  git -C "${ORML_PATH}" sparse-checkout set oracle traits utilities
+  git -C "${ORML_PATH}" sparse-checkout list
+else
+  echo "*** git sparse-checkout unavailable (needs git >= 2.25)"
+  echo "*** keeping the full ${ORML_PATH} checkout -- builds are unaffected"
+fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+"$(dirname "$0")/init-submodules.sh"
+
 echo "*** Initializing WASM build environment"
 
 rustup install 1.90.0


### PR DESCRIPTION
**Draft / WIP.** Phase 1 of [ADR-001](https://github.com/CEF-AI/company-memory-bank/pull/125), implementing [this plan](https://github.com/CEF-AI/company-memory-bank/pull/127). Started as a dependency spike; now contains the working oracle integration plus the CI repairs that were needed to prove it.

Governance will price cluster resources in **USD** while customers keep paying in **CERE**. This PR puts the CERE/USD rate source on chain. The conversion itself is [`ddc-payouts` #77](https://github.com/Cerebellum-Network/ddc-payouts/pull/77).

## What's here

**The oracle (`orml-oracle`)**
- Vendored as a `third_party/` git submodule tracking upstream `polkadot-stable2512`, following the convention already used by `ddc-api`, `ddc-dac` and `ddc-node`. Neither crates.io (newest release pins `frame-support ^41`; we are on 45.x) nor a plain git dependency works — upstream deliberately ships release branches without a root `Cargo.toml` ([orml #980](https://github.com/open-web3-stack/open-runtime-module-library/issues/980)), and a submodule is their recommended integration.
- Configured to ADR-001's parameters: `MinimumCount` 2 of 3 operators, `ExpiresIn` 3 h, one typed `PriceKey`, bounds sized to the actual design.
- Operator set is a governance-curated `pallet-membership` instance on `Instance4`, so feeders are added and removed by extrinsic rather than runtime upgrade. No members are seeded at genesis — ADR-001 §2 puts the set under governance.
- Provisional weights replace upstream's, which were benchmarked on Acala hardware in 2021. Storage access counts are read off the extrinsic; the regeneration command is in the module header and both pallets are registered in `define_benchmarks!`, so real numbers are one command before mainnet.
- Wired into **both** runtimes. The four blocks were lifted from `cere-dev` programmatically rather than retyped and diffed afterwards, so devnet and mainnet pricing config cannot silently drift. `spec_version` → 80014 in both.

**CI repairs** (pre-existing breakage, surfaced because this branch is the first to need them)
- `submodules: true` on every `actions/checkout` — this repo had never had a submodule.
- `dprint`, `clippy` and `tarpaulin` exclude `third_party`; our lint policy should not apply to vendored code.
- `actions-rs/toolchain` → `dtolnay/rust-toolchain`. The archived action was force-run on Node 24 and died on the self-hosted runner, which is why `Run tests` was the only job failing.
- `HOME` exported for the self-hosted runner, which does not set it, so `git config --global` failed with `fatal: $HOME not set`.
- `spec_version` bump, which fixes `Try-Runtime Check` — that job had been red on `dev` since at least 2026-07-02.

## Verification

Every commit checked native **and** `no_std`/wasm, plus the `construct_runtime` integrity test on both runtimes. On CI, `Run tests` **passes for the first time on this branch** (1h6m), and `Try-Runtime Check` passes for the first time in over a month.

## Notes for reviewers

- **The CI commits are independently useful to `dev`** and don't need to wait on the oracle. Worth cherry-picking if this PR sits.
- **Weights are provisional, not benchmarked.** Worth a ticket so it isn't forgotten before mainnet.
- Four `actions-rs/toolchain` usages remain in `manual-build`, `security`, `stage` and `try-runtime-local`. Left alone deliberately — two are deployment workflows this PR doesn't exercise, so changing them here would be untested.
- The orml submodule checkout can be trimmed to the three crates actually built (1.4 M → 228 K) via `./scripts/init-submodules.sh`. That's per-clone config, so CI does a plain full checkout rather than carry another moving part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
