### PR TITLE
fix: record orml-oracle in the lockfile for cere-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "ismp",
  "ismp-grandpa",
  "log",
+ "orml-oracle",
  "pallet-chainbridge",
  "pallet-ddc-clusters",
  "pallet-ddc-clusters-gov",


### PR DESCRIPTION
One-line lockfile fix. **`dev` currently fails any `--locked` build.**

#731 added `orml-oracle` to `runtime/cere/Cargo.toml` but the commit staged only `runtime/cere/`, so the root `Cargo.lock` never recorded the new dependency edge. The manifests and the lockfile are out of sync on `dev`:

```
$ cargo metadata --locked
error: the lock file needs to be updated but --locked was passed to prevent this
exit 101
```

This is not cosmetic — the **Run tests** job runs `cargo tarpaulin --verbose --locked --no-fail-fast --workspace`, so it breaks on a fresh clone.

**Fix:** one line, regenerated by cargo, no version changes. Verified `cargo metadata --locked` exits 0 afterwards.

My mistake in #731; flagging it rather than folding it quietly into the next PR, since `dev` is affected right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)