### PR TITLE
feat(runtime): wire USD-denominated pricing into the payouts pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#fed9ca5b7cefefa124dcdbec20633161863617fa"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#0678634ec64f1febb01633affd84083ad0dc40ef"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#0678634ec64f1febb01633affd84083ad0dc40ef"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#e98fe5a4d31a4d1fb68dc24ded366cb343e5ac54"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#e98fe5a4d31a4d1fb68dc24ded366cb343e5ac54"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#2db3b22329d4dae117f74694b8823d3cc89cb9f5"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1766,8 +1766,13 @@ parameter_types! {
 /// operator submissions -- not a raw feed.
 pub struct CereUsdRate;
 impl pallet_ddc_payouts::PriceProvider for CereUsdRate {
-	fn current_rate() -> Option<u128> {
-		PriceOracle::get(&PriceKey::CereUsd).map(|timestamped| timestamped.value)
+	fn current_rate() -> Option<(u128, u64)> {
+		// The observation time travels with the rate. orml writes its combined
+		// value only on a feed and never expires it, so once the feeders fall
+		// silent this keeps returning the last median -- and the payouts pallet
+		// needs the timestamp to tell a frozen answer from a fresh one.
+		PriceOracle::get(&PriceKey::CereUsd)
+			.map(|timestamped| (timestamped.value, timestamped.timestamp))
 	}
 }
 

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -1722,10 +1722,21 @@ pub enum PriceKey {
 impl orml_oracle::Config for Runtime {
 	type OnNewData = ();
 	// Median over unexpired operator submissions. Below MinimumCount fresh
-	// values the previous median is kept rather than stalling. ADR-001:
-	// MinimumCount = 2 of 3 operators, ExpiresIn = 3h.
+	// values the previous median is kept rather than stalling.
+	//
+	// MinimumCount is 1 while the feeder set is being stood up, against
+	// ADR-001's 2-of-3. At 2 a lone operator submits successfully and still
+	// produces no median at all -- `combine_data` returns the previous value,
+	// `Values` is never written, and the oracle reads empty forever. Setting 1
+	// now means oracle-operator works the day it starts rather than needing a
+	// second runtime upgrade. Raise to 2 once three feeders are live; that is a
+	// runtime change, so it wants doing before the oracle is load-bearing.
+	//
+	// Inert while rates are set by governance through `force_set_rate`, which
+	// does not consult the oracle at all. ExpiresIn stays 3h; it only bites once
+	// a feeder actually runs.
 	type CombineData =
-		orml_oracle::DefaultCombineData<Runtime, ConstU32<2>, ConstU64<10_800_000>, ()>;
+		orml_oracle::DefaultCombineData<Runtime, ConstU32<1>, ConstU64<10_800_000>, ()>;
 	type Time = Timestamp;
 	type OracleKey = PriceKey;
 	type OracleValue = u128;
@@ -1747,15 +1758,30 @@ parameter_types! {
 	/// Ten minutes: short enough that an era is priced close to the rate that
 	/// held while it ran, long enough that the ring spans days rather than hours.
 	pub const RateEpochLength: BlockNumber = 10 * MINUTES;
-	/// 288 entries at ten minutes apart is 48 hours of history. ADR-001 requires
+	/// 4320 entries at ten minutes apart is 30 days of history. ADR-001 requires
 	/// `HistoryDepth x EpochLength` to exceed the worst-case payout lag, so that
 	/// an era retried long after the fact can still find the rate that applied
 	/// when it ran instead of halting.
-	pub const RateHistoryDepth: u32 = 288;
-	/// Three hours, matching the oracle's own `ExpiresIn`. Past this an entry is
-	/// refused rather than used, so a stalled feed halts payouts instead of
-	/// billing against a rate nobody is still vouching for.
-	pub const MaxRateAge: u64 = 10_800_000;
+	///
+	/// Inert while rates are being forced by governance -- a forced rate is
+	/// appended about once a year, so even a 288-ring would hold centuries. It
+	/// earns its place the moment a feeder starts filling the ring every ten
+	/// minutes: at 288 the ring wraps every 48 hours, so retrying an era from
+	/// last week finds no entry effective at or before it and halts regardless
+	/// of how generous `MaxRateAge` is. 4320 costs roughly 100 KB.
+	pub const RateHistoryDepth: u32 = 4320;
+	/// One year.
+	///
+	/// The bound exists so a stalled feed halts payouts instead of billing
+	/// against a rate nobody is still vouching for. While the rate is set by
+	/// governance through `force_set_rate` there is no staleness to detect -- a
+	/// manual set is a deliberate act -- and a three-hour bound would halt every
+	/// era three hours afterwards.
+	///
+	/// This is the wrong value once a feeder is live: at a year, a feed that
+	/// died in January still prices eras in December. Shorten it to hours in the
+	/// same change that raises MinimumCount to 2.
+	pub const MaxRateAge: u64 = 31_536_000_000;
 }
 
 /// Exposes the oracle's combined CERE/USD median to the payouts pallet.

--- a/runtime/cere-dev/src/lib.rs
+++ b/runtime/cere-dev/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80014,
+	spec_version: 80015,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1474,6 +1474,14 @@ parameter_types! {
 
 impl pallet_ddc_payouts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	// USD-denominated pricing (ADR-001). Cluster protocol params are quoted in
+	// atto-USD; the rate below converts each emitted amount into CERE.
+	type PriceOracle = CereUsdRate;
+	type GovernanceOrigin = EnsureRoot<AccountId>;
+	type EpochLength = RateEpochLength;
+	type HistoryDepth = RateHistoryDepth;
+	type TimeProvider = Timestamp;
+	type MaxRateAge = MaxRateAge;
 	type WeightInfo = pallet_ddc_payouts::weights::SubstrateWeight<Runtime>;
 	type PalletId = PayoutsPalletId;
 	type Currency = Balances;
@@ -1732,6 +1740,35 @@ impl orml_oracle::Config for Runtime {
 	type MaxFeedValues = ConstU32<1>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
+}
+
+parameter_types! {
+	/// How often the payouts pallet samples the oracle median into its ring.
+	/// Ten minutes: short enough that an era is priced close to the rate that
+	/// held while it ran, long enough that the ring spans days rather than hours.
+	pub const RateEpochLength: BlockNumber = 10 * MINUTES;
+	/// 288 entries at ten minutes apart is 48 hours of history. ADR-001 requires
+	/// `HistoryDepth x EpochLength` to exceed the worst-case payout lag, so that
+	/// an era retried long after the fact can still find the rate that applied
+	/// when it ran instead of halting.
+	pub const RateHistoryDepth: u32 = 288;
+	/// Three hours, matching the oracle's own `ExpiresIn`. Past this an entry is
+	/// refused rather than used, so a stalled feed halts payouts instead of
+	/// billing against a rate nobody is still vouching for.
+	pub const MaxRateAge: u64 = 10_800_000;
+}
+
+/// Exposes the oracle's combined CERE/USD median to the payouts pallet.
+///
+/// The pallet deliberately does not depend on orml: it declares its own
+/// `PriceProvider` boundary and this adapter is the only place the two meet.
+/// Read here is the aggregate the oracle already combined -- median of unexpired
+/// operator submissions -- not a raw feed.
+pub struct CereUsdRate;
+impl pallet_ddc_payouts::PriceProvider for CereUsdRate {
+	fn current_rate() -> Option<u128> {
+		PriceOracle::get(&PriceKey::CereUsd).map(|timestamped| timestamped.value)
+	}
 }
 
 #[polkadot_sdk::frame_support::runtime]

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 80014,
+	spec_version: 80015,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,
@@ -1443,6 +1443,14 @@ parameter_types! {
 
 impl pallet_ddc_payouts::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	// USD-denominated pricing (ADR-001). Cluster protocol params are quoted in
+	// atto-USD; the rate below converts each emitted amount into CERE.
+	type PriceOracle = CereUsdRate;
+	type GovernanceOrigin = EnsureRoot<AccountId>;
+	type EpochLength = RateEpochLength;
+	type HistoryDepth = RateHistoryDepth;
+	type TimeProvider = Timestamp;
+	type MaxRateAge = MaxRateAge;
 	type WeightInfo = pallet_ddc_payouts::weights::SubstrateWeight<Runtime>;
 	type PalletId = PayoutsPalletId;
 	type Currency = Balances;
@@ -1719,6 +1727,35 @@ impl orml_oracle::Config for Runtime {
 	type MaxFeedValues = ConstU32<1>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
+}
+
+parameter_types! {
+	/// How often the payouts pallet samples the oracle median into its ring.
+	/// Ten minutes: short enough that an era is priced close to the rate that
+	/// held while it ran, long enough that the ring spans days rather than hours.
+	pub const RateEpochLength: BlockNumber = 10 * MINUTES;
+	/// 288 entries at ten minutes apart is 48 hours of history. ADR-001 requires
+	/// `HistoryDepth x EpochLength` to exceed the worst-case payout lag, so that
+	/// an era retried long after the fact can still find the rate that applied
+	/// when it ran instead of halting.
+	pub const RateHistoryDepth: u32 = 288;
+	/// Three hours, matching the oracle's own `ExpiresIn`. Past this an entry is
+	/// refused rather than used, so a stalled feed halts payouts instead of
+	/// billing against a rate nobody is still vouching for.
+	pub const MaxRateAge: u64 = 10_800_000;
+}
+
+/// Exposes the oracle's combined CERE/USD median to the payouts pallet.
+///
+/// The pallet deliberately does not depend on orml: it declares its own
+/// `PriceProvider` boundary and this adapter is the only place the two meet.
+/// Read here is the aggregate the oracle already combined -- median of unexpired
+/// operator submissions -- not a raw feed.
+pub struct CereUsdRate;
+impl pallet_ddc_payouts::PriceProvider for CereUsdRate {
+	fn current_rate() -> Option<u128> {
+		PriceOracle::get(&PriceKey::CereUsd).map(|timestamped| timestamped.value)
+	}
 }
 
 #[polkadot_sdk::frame_support::runtime]

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1753,8 +1753,13 @@ parameter_types! {
 /// operator submissions -- not a raw feed.
 pub struct CereUsdRate;
 impl pallet_ddc_payouts::PriceProvider for CereUsdRate {
-	fn current_rate() -> Option<u128> {
-		PriceOracle::get(&PriceKey::CereUsd).map(|timestamped| timestamped.value)
+	fn current_rate() -> Option<(u128, u64)> {
+		// The observation time travels with the rate. orml writes its combined
+		// value only on a feed and never expires it, so once the feeders fall
+		// silent this keeps returning the last median -- and the payouts pallet
+		// needs the timestamp to tell a frozen answer from a fresh one.
+		PriceOracle::get(&PriceKey::CereUsd)
+			.map(|timestamped| (timestamped.value, timestamped.timestamp))
 	}
 }
 

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1709,10 +1709,21 @@ pub enum PriceKey {
 impl orml_oracle::Config for Runtime {
 	type OnNewData = ();
 	// Median over unexpired operator submissions. Below MinimumCount fresh
-	// values the previous median is kept rather than stalling. ADR-001:
-	// MinimumCount = 2 of 3 operators, ExpiresIn = 3h.
+	// values the previous median is kept rather than stalling.
+	//
+	// MinimumCount is 1 while the feeder set is being stood up, against
+	// ADR-001's 2-of-3. At 2 a lone operator submits successfully and still
+	// produces no median at all -- `combine_data` returns the previous value,
+	// `Values` is never written, and the oracle reads empty forever. Setting 1
+	// now means oracle-operator works the day it starts rather than needing a
+	// second runtime upgrade. Raise to 2 once three feeders are live; that is a
+	// runtime change, so it wants doing before the oracle is load-bearing.
+	//
+	// Inert while rates are set by governance through `force_set_rate`, which
+	// does not consult the oracle at all. ExpiresIn stays 3h; it only bites once
+	// a feeder actually runs.
 	type CombineData =
-		orml_oracle::DefaultCombineData<Runtime, ConstU32<2>, ConstU64<10_800_000>, ()>;
+		orml_oracle::DefaultCombineData<Runtime, ConstU32<1>, ConstU64<10_800_000>, ()>;
 	type Time = Timestamp;
 	type OracleKey = PriceKey;
 	type OracleValue = u128;
@@ -1734,15 +1745,30 @@ parameter_types! {
 	/// Ten minutes: short enough that an era is priced close to the rate that
 	/// held while it ran, long enough that the ring spans days rather than hours.
 	pub const RateEpochLength: BlockNumber = 10 * MINUTES;
-	/// 288 entries at ten minutes apart is 48 hours of history. ADR-001 requires
+	/// 4320 entries at ten minutes apart is 30 days of history. ADR-001 requires
 	/// `HistoryDepth x EpochLength` to exceed the worst-case payout lag, so that
 	/// an era retried long after the fact can still find the rate that applied
 	/// when it ran instead of halting.
-	pub const RateHistoryDepth: u32 = 288;
-	/// Three hours, matching the oracle's own `ExpiresIn`. Past this an entry is
-	/// refused rather than used, so a stalled feed halts payouts instead of
-	/// billing against a rate nobody is still vouching for.
-	pub const MaxRateAge: u64 = 10_800_000;
+	///
+	/// Inert while rates are being forced by governance -- a forced rate is
+	/// appended about once a year, so even a 288-ring would hold centuries. It
+	/// earns its place the moment a feeder starts filling the ring every ten
+	/// minutes: at 288 the ring wraps every 48 hours, so retrying an era from
+	/// last week finds no entry effective at or before it and halts regardless
+	/// of how generous `MaxRateAge` is. 4320 costs roughly 100 KB.
+	pub const RateHistoryDepth: u32 = 4320;
+	/// One year.
+	///
+	/// The bound exists so a stalled feed halts payouts instead of billing
+	/// against a rate nobody is still vouching for. While the rate is set by
+	/// governance through `force_set_rate` there is no staleness to detect -- a
+	/// manual set is a deliberate act -- and a three-hour bound would halt every
+	/// era three hours afterwards.
+	///
+	/// This is the wrong value once a feeder is live: at a year, a feed that
+	/// died in January still prices eras in December. Shorten it to hours in the
+	/// same change that raises MinimumCount to 2.
+	pub const MaxRateAge: u64 = 31_536_000_000;
 }
 
 /// Exposes the oracle's combined CERE/USD median to the payouts pallet.


### PR DESCRIPTION
Closes the loop opened by #731. That PR put the CERE/USD oracle on chain; this one connects it to the pallet that bills against it, so cluster protocol parameters quoted in atto-USD are actually settled in CERE.

**Depends on [ddc-payouts#81](https://github.com/Cerebellum-Network/ddc-payouts/pull/81).** Merge that first, then re-point `Cargo.lock` at `dev`'s new tip — it currently pins `e98fe5a4` on the fix branch, which `--locked` CI will reject because `branch = "dev"` does not contain it yet.

### Why one commit for the wiring

`dev` pins ddc-payouts by **branch**, and ddc-payouts `dev` already carries the new associated types. The lockfile bump and the Config items have to land together — refreshing the lock without implementing them does not compile.

Worth knowing: `dev` compiles today only because its lockfile is stale at `fed9ca5b`. Any `cargo update` touching this dependency breaks it. This PR closes that.

### Wiring

| Config item | Value |
|---|---|
| `PriceOracle` | `CereUsdRate`, an adapter over the orml aggregate. The pallet does not depend on orml — it declares its own `PriceProvider` boundary, and this adapter is the only place the two meet. |
| `GovernanceOrigin` | `EnsureRoot<AccountId>` |
| `EpochLength` | 10 minutes |
| `HistoryDepth` | 4320 (30 days) |
| `TimeProvider` | `Timestamp` |
| `MaxRateAge` | 1 year — see below |

`spec_version` 80014 → 80015. Applied **identically** to `cere-dev` and `cere`; the added blocks are byte-identical (43 lines each, diffed).

### Oracle parameters are tuned for a governance-forced rate, not a live feeder set

There is no feeder yet; the rate will be set by sudo `force_set_rate` until `oracle-operator` runs. Three values were retuned for that interim:

| | from | to |
|---|---|---|
| `MinimumCount` | 2 | **1** |
| `RateHistoryDepth` | 288 | **4320** |
| `MaxRateAge` | 3h | **1 year** |

`MinimumCount` is the one that bites immediately. At 2, **a lone operator submits successfully and still produces no median** — `combine_data` returns the previous value, `Values` is never written, and the oracle reads empty forever. Setting 1 now means `oracle-operator` works the day it starts rather than needing a second runtime upgrade.

The other two are inert while the rate is forced, but matter the moment a feeder runs. At 288 the ring wraps every 48 hours, so an era retried from last week finds no entry effective at or before it and halts however generous `MaxRateAge` is. 4320 costs ~100 KB. A 3-hour `MaxRateAge` would halt every era three hours after each manual set.

**These must be reverted together before the oracle is load-bearing.** At a 1-year bound, a feed that died in January still prices eras in December — precisely the staleness ddc-payouts#81 fixed, left switched off by the bound. Both runtimes carry a comment saying so.

### `PriceProvider` now carries the observation time

ddc-payouts#81 changed the trait from `fn current_rate() -> Option<u128>` to `Option<(u128, u64)>` — the rate plus the moment the observation was made, in unix ms. Both runtimes' `CereUsdRate` adapter returns the pair. The value it already read is orml's `TimestampedValue { value, timestamp }`, so this surfaces a field the adapter was discarding rather than sourcing anything new.

The lock is re-pinned `e98fe5a` → `2db3b22` (the #81 merge, current `dev` tip). Lockfile-only: one line, no other package moved.

**The timestamp is observation time and does not advance while feeders are quiet** — checked against orml rather than assumed:

- `Pallet::get` is `Self::values(key)`, a plain read of the `Values` map; it never recombines and never re-stamps (`oracle/src/lib.rs:215`).
- `Values` is written only inside `do_feed_values`, i.e. only when a feeder actually submits (`:249`).
- `DefaultCombineData` returns the median raw entry *itself*, carrying that feeder's own submission timestamp. `now()` is used only to filter expired entries, never to stamp the result (`default_combine_data.rs:27,37`).
- Below `MinimumCount` unexpired values it returns `prev_value` unchanged, so the stored entry keeps its original timestamp and ages out rather than being refreshed (`:31`).

So #81's fix works as intended here: a frozen aggregate ages instead of reading fresh forever. It stays switched off in practice while `MaxRateAge` is a year — see the section above.

### Verified

- `cargo check` on both runtimes, plus `try-runtime` and `runtime-benchmarks` features
- `cargo +nightly fmt --check` clean
- Added blocks diffed byte-for-byte between the two runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

