### PR TITLE
tools: add migration-eval, a value-level migration harness

### DIFF
--- a/tools/migration-eval/.gitignore
+++ b/tools/migration-eval/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.chopsticks.yml
+.chopsticks.sqlite*

--- a/tools/migration-eval/README.md
+++ b/tools/migration-eval/README.md
@@ -19,10 +19,18 @@ the two decodings.
 ## Usage
 
 ```bash
-cargo build --release -p cere-runtime          # produce the candidate wasm
+# WASM_BUILD_WORKSPACE_HINT is not optional. Without it, substrate-wasm-builder
+# cannot find the workspace Cargo.lock, generates its own beside the artifact,
+# and can pin different git revisions than the workspace — producing a wasm built
+# from stale sources while the native build uses current ones.
+WASM_BUILD_WORKSPACE_HINT="$PWD" cargo build --release -p cere-runtime
+
 cd tools/migration-eval && npm install
 npm run eval -- scenarios/mainnet-release-1.yml
 ```
+
+The tool prints the git revisions it found in the wasm build's own lock file, and
+a scenario can pin them under `runtime.deps` to make a mismatch fatal.
 
 Exit code is non-zero if any assertion fails.
 
@@ -82,6 +90,19 @@ printed on failure, so a red run explains itself.
 was not written for. This is not theoretical: during development a scenario was
 run against a stale wasm and the unchanged result was briefly read as a fix
 failing to work. Pin it.
+
+**`sha256` is not sufficient on its own.** It proves you tested the artifact you
+named — not that the artifact was built from the sources you think.
+substrate-wasm-builder runs a nested cargo build with its own `Cargo.lock`
+written beside the wasm; if it cannot find the workspace lock it generates one
+independently. That happened here: the workspace resolved
+`ddc-payouts#8178000c` while the wasm was built from `#b8988623`, so a verified
+fix appeared not to work and the runtime hash was byte-identical across the
+change — correctly, because it *was* the same wasm.
+
+So the tool reads that lock and reports the revisions compiled into the artifact.
+Pin them under `runtime.deps` when a scenario depends on a specific fix being
+present.
 
 ## Limits
 

--- a/tools/migration-eval/README.md
+++ b/tools/migration-eval/README.md
@@ -1,0 +1,101 @@
+# migration-eval
+
+Evaluates a candidate runtime's storage migrations against **real chain state**.
+
+## Why this exists
+
+Migration bugs on this chain do not look like crashes. They look like success.
+
+Evaluation round 1 found `ddc-payouts` v2 skipping all 58 Mainnet billing
+reports, then v3 reading the same bytes under a different layout that is *also*
+exactly 167 bytes — decoding cleanly and writing rewards inflated by 4.2e12×.
+try-runtime's own checks passed, because the migration's `pre_upgrade` and
+`post_upgrade` both counted undecodable entries and compared `0 == 0`.
+
+A tool that asks "did it error?" ships that. This one asks whether the **values
+still mean the same thing**, by capturing storage before and after and comparing
+the two decodings.
+
+## Usage
+
+```bash
+cargo build --release -p cere-runtime          # produce the candidate wasm
+cd tools/migration-eval && npm install
+npm run eval -- scenarios/mainnet-release-1.yml
+```
+
+Exit code is non-zero if any assertion fails.
+
+## How it works
+
+1. Fork the target chain with Chopsticks — **without** the candidate runtime, so
+   the first capture decodes with pre-upgrade metadata.
+2. Snapshot the storage items named under `capture:`.
+3. Write the candidate wasm to `:code`. `on_runtime_upgrade` fires on the next
+   block, exactly as it would from a real `set_code`.
+4. Drive blocks until `MultiBlockMigrations::Cursor` clears, recording per-block
+   weight and migration events. Capped by `maxBlocks`, so a migration that never
+   terminates fails loudly instead of hanging.
+5. Reconnect, so metadata is now post-upgrade, and snapshot again.
+6. Evaluate the assertions across the two snapshots.
+
+Steps 1 and 5 are the point: the same bytes decoded under two type universes is
+what makes a misaligned-layout migration visible.
+
+## Scenarios are specifications
+
+A scenario states what a release **must** do, and is written from evaluation
+findings *before* the fix exists. `expect: fails` marks an assertion that is
+known to fail today, so an unexpected failure is distinguishable from a known
+one.
+
+If a fix cannot satisfy an assertion and the assertion is changed instead, that
+shows up as its own diff. Treat it as a question, not a detail.
+
+## Assertions
+
+| Form | Meaning |
+|---|---|
+| `count: {equals: N}` | exactly N entries after |
+| `count: {unchanged: true}` | same count before and after |
+| `sum: {field: f, unchanged: true}` | Σf identical before and after |
+| `sum: {field: f, equalsBefore: {item, field}}` | Σf after equals Σ of another item before — for renamed storage |
+| `weight: {peakBlock: "<100%"}` | no block exceeds the limit |
+
+`because:` is required prose explaining what the assertion protects. It is
+printed on failure, so a red run explains itself.
+
+## Two Chopsticks requirements, both non-obvious
+
+- **`allowUnresolvedImports: true`** — the runtime imports
+  `ext_ddc_dac_close_session_version_1` from `ddc-dac-host`. Chopsticks provides
+  only the standard host-function set, so without this it fails at
+  instantiation. Unresolved imports then trap only if *called*; migrations touch
+  storage rather than DAC sessions, so this is safe. **A migration that calls a
+  `ddc-dac-host` function cannot be evaluated here** — use try-runtime.
+- **`prefetch:`** — lazy per-key fetching against a ~1s-per-call endpoint stalls
+  block building past any sane RPC timeout.
+
+## Runtime pinning
+
+`runtime.sha256` makes the tool refuse to run against an artifact the scenario
+was not written for. This is not theoretical: during development a scenario was
+run against a stale wasm and the unchanged result was briefly read as a fix
+failing to work. Pin it.
+
+## Limits
+
+- Chopsticks mocks consensus, so wall-clock timing means nothing. Block *counts*
+  are meaningful; block *durations* are not.
+- Migration `pre_upgrade`/`post_upgrade` hooks do not run — those need
+  try-runtime. Given round 1, that is a small loss.
+- `sum:` walks decoded JSON for a named field, matching either the Rust
+  snake_case name or the camelCase that `toJSON()` emits. A field that resolves
+  on neither side is reported as **FIELD NOT FOUND — assertion proved nothing**,
+  never as a value comparison. That distinction matters: an assertion that
+  silently reads nothing and passes is the same failure mode as a migration's
+  `ensure!(0 == 0)`, which is what this tool exists to catch.
+- The reported `spec` version does not change after the `:code` write —
+  Chopsticks caches it. Cosmetic only; the metadata genuinely updates, which is
+  observable in that `DdcCustomers::Ledger` reads as absent afterwards because
+  the new runtime renamed it to `ClusterLedger`.

--- a/tools/migration-eval/README.md
+++ b/tools/migration-eval/README.md
@@ -30,7 +30,21 @@ npm run eval -- scenarios/mainnet-release-1.yml
 ```
 
 The tool prints the git revisions it found in the wasm build's own lock file, and
-a scenario can pin them under `runtime.deps` to make a mismatch fatal.
+a scenario can pin them under `runtime.deps` to make a mismatch fatal. Printing
+is not checking: a revision that only appears in the log proves nothing about
+what the run enforced. Pin what the scenario depends on.
+
+To evaluate a build outside the default target dir — a second worktree, a shared
+`CARGO_TARGET_DIR` — set `MIGRATION_EVAL_WASM` rather than editing the scenario's
+`wasm:` path. Editing it forks the file, and a scenario that diverges from the one
+in git is a scenario nobody has actually run:
+
+```bash
+MIGRATION_EVAL_WASM=/path/to/cere_runtime.compact.compressed.wasm \
+  npm run eval -- scenarios/mainnet-release-1.yml
+```
+
+The override is announced in the output, never silent.
 
 Exit code is non-zero if any assertion fails.
 
@@ -56,6 +70,11 @@ A scenario states what a release **must** do, and is written from evaluation
 findings *before* the fix exists. `expect: fails` marks an assertion that is
 known to fail today, so an unexpected failure is distinguishable from a known
 one.
+
+**Remove `expect: fails` the moment the fix lands.** Left behind, it reclassifies
+a future regression as already-known and drops it out of the unexpected count —
+the scenario goes quiet exactly when it should shout. It is scaffolding for a
+known-broken window, not a permanent annotation.
 
 If a fix cannot satisfy an assertion and the assertion is changed instead, that
 shows up as its own diff. Treat it as a question, not a detail.
@@ -126,7 +145,11 @@ present.
   never as a value comparison. That distinction matters: an assertion that
   silently reads nothing and passes is the same failure mode as a migration's
   `ensure!(0 == 0)`, which is what this tool exists to catch.
-- The reported `spec` version does not change after the `:code` write —
-  Chopsticks caches it. Cosmetic only; the metadata genuinely updates, which is
-  observable in that `DdcCustomers::Ledger` reads as absent afterwards because
-  the new runtime renamed it to `ClusterLedger`.
+- `state_getRuntimeVersion` reports the version Chopsticks resolved for the fork,
+  not the one the head is executing, so it does not move across a `:code` write.
+  The tool therefore reads the applied version from `System::LastRuntimeUpgrade`,
+  which `frame_executive` writes while applying the upgrade, and asserts that it
+  advanced. This is not cosmetic: `frame_executive` runs `on_runtime_upgrade`
+  only when the runtime's `spec_version` differs from that value, so a release
+  that forgets the bump is a silent no-op on a real chain — every migration
+  skipped, no error anywhere. It is the one check that catches that.

--- a/tools/migration-eval/README.md
+++ b/tools/migration-eval/README.md
@@ -65,6 +65,7 @@ shows up as its own diff. Treat it as a question, not a detail.
 | Form | Meaning |
 |---|---|
 | `count: {equals: N}` | exactly N entries after |
+| `rawCount: {equals: N}` | N keys under the raw `twox128` prefix, bypassing metadata |
 | `count: {unchanged: true}` | same count before and after |
 | `sum: {field: f, unchanged: true}` | Σf identical before and after |
 | `sum: {field: f, equalsBefore: {item, field}}` | Σf after equals Σ of another item before — for renamed storage |
@@ -72,6 +73,15 @@ shows up as its own diff. Treat it as a question, not a detail.
 
 `because:` is required prose explaining what the assertion protects. It is
 printed on failure, so a red run explains itself.
+
+**Use `rawCount:` when a migration renames a storage item.** The old item is
+absent from post-upgrade metadata, so a metadata-driven `count:` cannot tell
+"the prefix is empty" from "the item no longer exists" — it reports `n/a` either
+way, and the assertion can never pass however the migration behaves. `rawCount:`
+pages `state_getKeysPaged` over `twox128(pallet) ++ twox128(item)` and sees data
+orphaned under a prefix the runtime has stopped declaring. That is the shape of
+the `v4_mbm` copy-without-remove bug: 535 entries left somewhere the runtime no
+longer looks.
 
 ## Two Chopsticks requirements, both non-obvious
 

--- a/tools/migration-eval/package.json
+++ b/tools/migration-eval/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@cere/migration-eval",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Evaluate a candidate runtime's storage migrations against real chain state.",
+  "bin": { "migration-eval": "src/cli.mjs" },
+  "scripts": {
+    "eval": "node src/cli.mjs"
+  },
+  "dependencies": {
+    "@acala-network/chopsticks": "^1.5.1",
+    "@polkadot/api": "^16.5.6",
+    "yaml": "^2.5.0"
+  }
+}

--- a/tools/migration-eval/package.json
+++ b/tools/migration-eval/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "description": "Evaluate a candidate runtime's storage migrations against real chain state.",
-  "bin": { "migration-eval": "src/cli.mjs" },
+  "bin": {
+    "migration-eval": "src/cli.mjs"
+  },
   "scripts": {
     "eval": "node src/cli.mjs"
   },
@@ -12,5 +14,9 @@
     "@acala-network/chopsticks": "^1.5.1",
     "@polkadot/api": "^16.5.6",
     "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@polkadot/util": "^14.0.3",
+    "@polkadot/util-crypto": "^14.0.3"
   }
 }

--- a/tools/migration-eval/scenarios/mainnet-release-1.yml
+++ b/tools/migration-eval/scenarios/mainnet-release-1.yml
@@ -1,8 +1,9 @@
 # Release 1 of the Mainnet launch line: spec 73158 -> 73159.
 #
-# This scenario is a SPECIFICATION, not a description. It asserts what release 1
-# must do to Mainnet state. It is expected to FAIL until the migration fixes
-# land — see `expect` on each assertion for the currently-known result.
+# This scenario is a SPECIFICATION, not a description: it asserts what release 1
+# must do to Mainnet state, independent of what the current code does. Every
+# assertion passes as of the fixes in `feat/migration-fixes`. Do not add
+# `expect: fails` to silence a regression — a failure here is the point.
 name: mainnet-release-1
 description: >
   Ported DDC pallets with the payout inspector stubbed. Migrates
@@ -32,8 +33,10 @@ runtime:
   # artifact you named, not that it came from the sources you think.
   #
   # Build with WASM_BUILD_WORKSPACE_HINT=<workspace root> so the two agree.
-  # deps:
-  #   ddc-payouts: 8178000c
+  deps:
+    # Carries the payouts v1-v5 migration fixes. An earlier revision here
+    # corrupts PayoutReceipts reward sums, and the wasm looks identical.
+    ddc-payouts: 8178000c
 
 capture:
   - DdcCustomers::Ledger
@@ -55,15 +58,16 @@ assert:
     - item: DdcCustomers::ClusterLedger
       count: { equals: 535 }
       because: v4_mbm must move all 535 ledgers, not a subset
-      expect: fails
     - item: DdcCustomers::Ledger
       # NOT `count:`. The new runtime renames this item to ClusterLedger, so it
       # is absent from post-upgrade metadata and a metadata-driven query cannot
       # distinguish "empty" from "no longer exists". Only a raw key count over
       # the twox128 prefix can see data orphaned there.
       rawCount: { equals: 0 }
-      because: v4_mbm currently copies without removing, stranding all 535 entries
-      expect: fails
+      because: >
+        v4_mbm must remove each source entry as it writes the destination.
+        Copying without removing strands all 535 under the old prefix, where
+        nothing reads them and nothing reports them.
     - item: DdcCustomers::Buckets
       count: { unchanged: true }
       because: Bucket is byte-identical between refs, so nothing should touch it
@@ -73,9 +77,10 @@ assert:
         field: total_distributed_rewards
         equalsBefore: { item: DdcPayouts::ActiveBillingReports, field: total_distributed_reward }
       because: >
-        payouts v2 skips all 58 records and v3 reads them under a misaligned
-        layout that is also 167 bytes, inflating rewards ~4.2e12x
-      expect: fails
+        All 58 records must survive with reward totals byte-preserved. The
+        failure mode is silent: v1::CustomerCharge and v2 differ by one field
+        but both encode to 167 bytes, so a misaligned read decodes cleanly and
+        inflates rewards ~2.1e12x rather than erroring.
     - item: Balances::Holds
       count: { unchanged: true }
       sum: { field: amount, unchanged: true }

--- a/tools/migration-eval/scenarios/mainnet-release-1.yml
+++ b/tools/migration-eval/scenarios/mainnet-release-1.yml
@@ -57,8 +57,12 @@ assert:
       because: v4_mbm must move all 535 ledgers, not a subset
       expect: fails
     - item: DdcCustomers::Ledger
-      count: { equals: 0 }
-      because: v4_mbm currently copies without removing, stranding the source prefix
+      # NOT `count:`. The new runtime renames this item to ClusterLedger, so it
+      # is absent from post-upgrade metadata and a metadata-driven query cannot
+      # distinguish "empty" from "no longer exists". Only a raw key count over
+      # the twox128 prefix can see data orphaned there.
+      rawCount: { equals: 0 }
+      because: v4_mbm currently copies without removing, stranding all 535 entries
       expect: fails
     - item: DdcCustomers::Buckets
       count: { unchanged: true }

--- a/tools/migration-eval/scenarios/mainnet-release-1.yml
+++ b/tools/migration-eval/scenarios/mainnet-release-1.yml
@@ -24,6 +24,16 @@ runtime:
   wasm: ../../../target/release/wbuild/cere-runtime/cere_runtime.compact.compressed.wasm
   # Pin to refuse a run against a stale artifact. Omit to skip the check.
   # sha256: ...
+  #
+  # Pin the git revisions actually compiled INTO the wasm. substrate-wasm-builder
+  # resolves dependencies through its own Cargo.lock beside the artifact, which
+  # can diverge from the workspace lock and silently produce a wasm built from
+  # stale sources. sha256 alone cannot detect that — it proves you tested the
+  # artifact you named, not that it came from the sources you think.
+  #
+  # Build with WASM_BUILD_WORKSPACE_HINT=<workspace root> so the two agree.
+  # deps:
+  #   ddc-payouts: 8178000c
 
 capture:
   - DdcCustomers::Ledger

--- a/tools/migration-eval/scenarios/mainnet-release-1.yml
+++ b/tools/migration-eval/scenarios/mainnet-release-1.yml
@@ -1,0 +1,70 @@
+# Release 1 of the Mainnet launch line: spec 73158 -> 73159.
+#
+# This scenario is a SPECIFICATION, not a description. It asserts what release 1
+# must do to Mainnet state. It is expected to FAIL until the migration fixes
+# land — see `expect` on each assertion for the currently-known result.
+name: mainnet-release-1
+description: >
+  Ported DDC pallets with the payout inspector stubbed. Migrates
+  clusters 2->6, nodes 0->2, payouts 0->5, customers 1->4.
+  customers 4->5 is deliberately out of scope (release 2).
+
+fork:
+  endpoint: wss://rpc.mainnet.cere.network/ws
+  at: latest
+  # The runtime imports ext_ddc_dac_close_session_version_1 from ddc-dac-host.
+  # Chopsticks provides only the standard host set, so without this it fails at
+  # instantiation. Unresolved imports then trap only if actually called —
+  # migrations touch storage, not DAC sessions, so this is safe here.
+  allowUnresolvedImports: true
+  # Lazy per-key fetching against a ~1s-per-call endpoint stalls block building.
+  prefetch: [System, Balances, DdcCustomers, DdcClusters, DdcNodes, DdcPayouts, DdcStaking]
+
+runtime:
+  wasm: ../../../target/release/wbuild/cere-runtime/cere_runtime.compact.compressed.wasm
+  # Pin to refuse a run against a stale artifact. Omit to skip the check.
+  # sha256: ...
+
+capture:
+  - DdcCustomers::Ledger
+  - DdcCustomers::Buckets
+  - DdcPayouts::ActiveBillingReports
+  - Balances::Holds
+
+drive:
+  until: mbm-cursor-clear
+  maxBlocks: 400
+
+assert:
+  weight:
+    # A block over 100% would be rejected by validators.
+    peakBlock: "<100%"
+    warnAbove: "90%"
+
+  storage:
+    - item: DdcCustomers::ClusterLedger
+      count: { equals: 535 }
+      because: v4_mbm must move all 535 ledgers, not a subset
+      expect: fails
+    - item: DdcCustomers::Ledger
+      count: { equals: 0 }
+      because: v4_mbm currently copies without removing, stranding the source prefix
+      expect: fails
+    - item: DdcCustomers::Buckets
+      count: { unchanged: true }
+      because: Bucket is byte-identical between refs, so nothing should touch it
+    - item: DdcPayouts::PayoutReceipts
+      count: { equals: 58 }
+      sum:
+        field: total_distributed_rewards
+        equalsBefore: { item: DdcPayouts::ActiveBillingReports, field: total_distributed_reward }
+      because: >
+        payouts v2 skips all 58 records and v3 reads them under a misaligned
+        layout that is also 167 bytes, inflating rewards ~4.2e12x
+      expect: fails
+    - item: Balances::Holds
+      count: { unchanged: true }
+      sum: { field: amount, unchanged: true }
+      because: >
+        RuntimeHoldReason's outer variant is the pallet index. Appending
+        DdcVerification instead of inserting keeps all 914 entries decodable.

--- a/tools/migration-eval/src/cli.mjs
+++ b/tools/migration-eval/src/cli.mjs
@@ -41,8 +41,12 @@ try {
   // Reconnect so polkadot-js picks up POST-upgrade metadata.
   await api.disconnect();
   api = await connect(url);
-  const specAfter = (await api.rpc.state.getRuntimeVersion()).specVersion.toNumber();
-  console.log(`\n  spec ${specBefore} -> ${specAfter},  blocks driven ${run.blocks.length}`);
+  // `state_getRuntimeVersion` reports the version chopsticks resolved for the
+  // fork, not the one the head is running, so it does not move across a
+  // `:code` swap. System::LastRuntimeUpgrade is written by frame_executive
+  // itself while applying the upgrade, so it is the authoritative record.
+  const specAfter = (await api.query.system.lastRuntimeUpgrade()).unwrap().specVersion.toNumber();
+  console.log(`\n  spec ${specBefore} -> ${specAfter} (System::LastRuntimeUpgrade),  blocks driven ${run.blocks.length}`);
 
   const after = await capture(api, [...(scenario.capture ?? []), ...(scenario.assert?.storage ?? []).map((s) => s.item)]);
   // Raw-prefix counts, for items whose metadata entry disappears in the upgrade.
@@ -51,6 +55,18 @@ try {
     if (s.rawCount) raw[s.item] = await countRawPrefix(api, s.item);
 
   const results = evaluate(scenario, before, after, run, raw);
+
+  // A candidate that forgets to bump spec_version is a silent no-op on a real
+  // chain: frame_executive only runs on_runtime_upgrade when the runtime's
+  // spec_version differs from System::LastRuntimeUpgrade. Assert it explicitly
+  // rather than leaving it to a reader to notice two equal numbers.
+  results.unshift({
+    name: 'spec_version bumped by the candidate runtime',
+    ok: specAfter > specBefore,
+    severity: 'fail',
+    detail: `${specBefore} -> ${specAfter}`,
+    because: 'frame_executive skips on_runtime_upgrade entirely when spec_version is unchanged, so no migration would run on Mainnet',
+  });
 
   console.log(`\n  ${'-'.repeat(66)}`);
   let failed = 0, surprises = 0;

--- a/tools/migration-eval/src/cli.mjs
+++ b/tools/migration-eval/src/cli.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+import { checkRuntime, startFork } from './fork.mjs';
+import { connect, capture, drive, evaluate } from './engine.mjs';
+
+const scenarioPath = resolve(process.argv[2] ?? 'scenarios/mainnet-release-1.yml');
+const scenario = parse(readFileSync(scenarioPath, 'utf8'));
+
+console.log(`\n  scenario  ${scenario.name}`);
+const rt = checkRuntime(scenarioPath, scenario.runtime);
+console.log(`  runtime   ${rt.wasm.split('/').slice(-1)[0]}  sha256=${rt.sha.slice(0, 16)}…  ${rt.bytes.length} bytes`);
+console.log(`  fork      ${scenario.fork.endpoint} @ ${scenario.fork.at}\n`);
+
+const { proc, url } = await startFork(scenario.fork);
+let api = await connect(url);
+try {
+  const specBefore = (await api.rpc.state.getRuntimeVersion()).specVersion.toNumber();
+  const head = (await api.rpc.chain.getHeader()).number.toNumber();
+  console.log(`  forked at #${head}, spec ${specBefore}`);
+
+  // Capture with PRE-upgrade metadata.
+  const before = await capture(api, scenario.capture ?? []);
+  for (const [k, v] of Object.entries(before)) console.log(`    before  ${k.padEnd(38)} ${v.missing ? 'absent' : v.count}`);
+
+  // Apply the candidate runtime by writing `:code`. on_runtime_upgrade fires on
+  // the next block, exactly as it would from a real set_code.
+  console.log(`\n  applying candidate runtime via :code …`);
+  // `:code` = 0x3a636f6465. Chopsticks takes raw keys as [key, value] pairs.
+  await api.rpc('dev_setStorage', [['0x3a636f6465', '0x' + rt.bytes.toString('hex')]]);
+
+  const run = await drive(api, scenario.drive ?? {});
+  for (const b of run.blocks)
+    console.log(`    #${b.number}  ${String(b.pct.toFixed(2)).padStart(7)}%  ${b.events.join(', ') || (b.cursorActive ? 'cursor active' : '')}`);
+  if (!run.terminated) console.log(`    !! hit maxBlocks — migrations did not terminate`);
+
+  // Reconnect so polkadot-js picks up POST-upgrade metadata.
+  await api.disconnect();
+  api = await connect(url);
+  const specAfter = (await api.rpc.state.getRuntimeVersion()).specVersion.toNumber();
+  console.log(`\n  spec ${specBefore} -> ${specAfter},  blocks driven ${run.blocks.length}`);
+
+  const after = await capture(api, [...(scenario.capture ?? []), ...(scenario.assert?.storage ?? []).map((s) => s.item)]);
+  const results = evaluate(scenario, before, after, run);
+
+  console.log(`\n  ${'-'.repeat(66)}`);
+  let failed = 0, surprises = 0;
+  for (const r of results) {
+    const known = r.expected === 'fails';
+    if (!r.ok && r.severity === 'fail') { failed++; if (!known) surprises++; }
+    const mark = r.ok ? 'PASS' : r.severity === 'warn' ? 'WARN' : known ? 'FAIL (known)' : 'FAIL';
+    console.log(`  ${mark.padEnd(13)} ${(r.item ? r.item + ' ' : '') + r.name}`);
+    console.log(`                ${r.detail}`);
+    if (!r.ok && r.because) console.log(`                why: ${r.because.replace(/\s+/g, ' ')}`);
+  }
+  console.log(`  ${'-'.repeat(66)}`);
+  console.log(`  ${results.filter((r) => r.ok).length} passed, ${failed} failed` +
+              (failed ? `  (${failed - surprises} known, ${surprises} unexpected)` : ''));
+  process.exitCode = failed ? 1 : 0;
+} finally {
+  await api?.disconnect().catch(() => {});
+  proc.kill();
+}

--- a/tools/migration-eval/src/cli.mjs
+++ b/tools/migration-eval/src/cli.mjs
@@ -11,7 +11,10 @@ const scenario = parse(readFileSync(scenarioPath, 'utf8'));
 console.log(`\n  scenario  ${scenario.name}`);
 const rt = checkRuntime(scenarioPath, scenario.runtime);
 console.log(`  runtime   ${rt.wasm.split('/').slice(-1)[0]}  sha256=${rt.sha.slice(0, 16)}…  ${rt.bytes.length} bytes`);
-console.log(`  fork      ${scenario.fork.endpoint} @ ${scenario.fork.at}\n`);
+console.log(`  fork      ${scenario.fork.endpoint} @ ${scenario.fork.at}`);
+for (const [crate, d] of Object.entries(rt.deps ?? {}))
+  console.log(`  dep       ${crate.padEnd(18)} ${d.rev.slice(0, 8)}  (${d.branch})`);
+console.log('');
 
 const { proc, url } = await startFork(scenario.fork);
 let api = await connect(url);

--- a/tools/migration-eval/src/cli.mjs
+++ b/tools/migration-eval/src/cli.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse } from 'yaml';
 import { checkRuntime, startFork } from './fork.mjs';
-import { connect, capture, drive, evaluate } from './engine.mjs';
+import { connect, capture, drive, evaluate, countRawPrefix } from './engine.mjs';
 
 const scenarioPath = resolve(process.argv[2] ?? 'scenarios/mainnet-release-1.yml');
 const scenario = parse(readFileSync(scenarioPath, 'utf8'));
@@ -45,7 +45,12 @@ try {
   console.log(`\n  spec ${specBefore} -> ${specAfter},  blocks driven ${run.blocks.length}`);
 
   const after = await capture(api, [...(scenario.capture ?? []), ...(scenario.assert?.storage ?? []).map((s) => s.item)]);
-  const results = evaluate(scenario, before, after, run);
+  // Raw-prefix counts, for items whose metadata entry disappears in the upgrade.
+  const raw = {};
+  for (const s of scenario.assert?.storage ?? [])
+    if (s.rawCount) raw[s.item] = await countRawPrefix(api, s.item);
+
+  const results = evaluate(scenario, before, after, run, raw);
 
   console.log(`\n  ${'-'.repeat(66)}`);
   let failed = 0, surprises = 0;

--- a/tools/migration-eval/src/engine.mjs
+++ b/tools/migration-eval/src/engine.mjs
@@ -1,0 +1,129 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+export const connect = (url) =>
+  ApiPromise.create({ provider: new WsProvider(url, 2500, {}, 900000), noInitWarn: true });
+
+const split = (spec) => { const [p, i] = spec.split('::'); return [lower(p), lower(i)]; };
+const lower = (s) => s.charAt(0).toLowerCase() + s.slice(1);
+
+/**
+ * Snapshot named storage items, decoded with whatever metadata the connection
+ * currently has. Called once before the upgrade (pre-metadata types) and once
+ * after (post-metadata types) -- comparing the two is how a migration that
+ * reinterprets old bytes under a new layout becomes visible.
+ */
+export async function capture(api, items) {
+  const out = {};
+  for (const spec of items) {
+    const [p, i] = split(spec);
+    if (!api.query[p]?.[i]) { out[spec] = { missing: true, entries: [] }; continue; }
+    const entries = await api.query[p][i].entries();
+    out[spec] = {
+      count: entries.length,
+      entries: entries.map(([k, v]) => ({ key: k.toHex(), value: v.toJSON() })),
+    };
+  }
+  return out;
+}
+
+/** Sum a numeric field across captured entries. Returns null if absent. */
+export function sumField(cap, field) {
+  if (!cap || cap.missing) return null;
+  let total = 0n, seen = 0;
+  for (const { value } of cap.entries) {
+    const v = pluck(value, field);
+    if (v === undefined || v === null) continue;
+    total += BigInt(typeof v === 'string' ? v : Math.trunc(Number(v)));
+    seen++;
+  }
+  return seen ? total : null;
+}
+
+const camel = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+
+function pluck(obj, field) {
+  if (obj == null || typeof obj !== 'object') return undefined;
+  for (const k of [field, camel(field)]) if (k in obj) return obj[k];
+  for (const v of Object.values(obj)) { const r = pluck(v, field); if (r !== undefined) return r; }
+  return undefined;
+}
+
+/** Drive blocks until the multi-block migration cursor clears. */
+export async function drive(api, { maxBlocks = 400 } = {}) {
+  const maxBlock = api.consts.system.blockWeights.maxBlock.refTime.toBigInt();
+  const blocks = [];
+  let done = false;
+  for (let i = 0; i < maxBlocks && !done; i++) {
+    await api.rpc('dev_newBlock', { count: 1 });
+    const hdr = await api.rpc.chain.getHeader();
+    const w = await api.query.system.blockWeight();
+    const used = w.mandatory.refTime.toBigInt() + w.normal.refTime.toBigInt() + w.operational.refTime.toBigInt();
+    const cursor = await api.query.multiBlockMigrations?.cursor?.();
+    const events = (await api.query.system.events())
+      .filter((r) => r.event.section === 'multiBlockMigrations')
+      .map((r) => r.event.method);
+    blocks.push({ number: hdr.number.toNumber(), used, pct: Number(used * 10000n / maxBlock) / 100, cursorActive: cursor?.isSome ?? false, events });
+    if (i > 0 && cursor && cursor.isNone) done = true;
+  }
+  return { maxBlock, blocks, terminated: done };
+}
+
+/** Evaluate the scenario's assertions against before/after captures. */
+export function evaluate(scenario, before, after, run) {
+  const results = [];
+  const a = scenario.assert ?? {};
+
+  if (a.weight) {
+    const peak = run.blocks.reduce((m, b) => (b.used > m ? b.used : m), 0n);
+    const pct = Number(peak * 10000n / run.maxBlock) / 100;
+    for (const [k, limit] of Object.entries(a.weight)) {
+      const bound = Number(String(limit).replace(/[<>%]/g, ''));
+      const ok = pct < bound;
+      results.push({
+        kind: 'weight', name: `${k} ${limit}`, ok,
+        detail: `peak ${peak} = ${pct.toFixed(2)}% of maxBlock`,
+        severity: k === 'warnAbove' ? 'warn' : 'fail',
+      });
+    }
+  }
+
+  for (const s of a.storage ?? []) {
+    const bef = before[s.item], aft = after[s.item];
+    if (s.count?.equals !== undefined)
+      results.push(check(s, `count == ${s.count.equals}`, aft?.count === s.count.equals, `count=${aft?.count ?? 'n/a'}`));
+    if (s.count?.unchanged)
+      results.push(check(s, 'count unchanged', bef?.count === aft?.count, `${bef?.count ?? 'n/a'} -> ${aft?.count ?? 'n/a'}`));
+    if (s.sum?.unchanged) {
+      const b = sumField(bef, s.sum.field), f = sumField(aft, s.sum.field);
+      results.push(sumResult(s, `sum(${s.sum.field}) unchanged`, b, f, b !== null && b === f));
+    }
+    if (s.sum?.equalsBefore) {
+      const b = sumField(before[s.sum.equalsBefore.item], s.sum.equalsBefore.field);
+      const f = sumField(aft, s.sum.field);
+      results.push(sumResult(s, `sum(${s.sum.field}) preserved from ${s.sum.equalsBefore.item}`, b, f, b !== null && f !== null && b === f));
+    }
+  }
+  return results;
+}
+
+/** Distinguish "field not found" from "values differ". A null sum means the
+ *  scenario names a field that does not exist in the decoded value -- the
+ *  assertion proved nothing, which must never read as a value comparison. */
+function sumResult(s, name, before, after, ok) {
+  if (before === null || after === null) {
+    const which = [before === null && 'before', after === null && 'after'].filter(Boolean).join(' and ');
+    return { kind: 'storage', item: s.item, name, ok: false, severity: 'fail', expected: null,
+      detail: `FIELD NOT FOUND in ${which} — assertion proved nothing`,
+      because: `scenario names field '${s.sum.field}'; check it exists in the decoded value` };
+  }
+  const ratio = Number(after * 1000n / before) / 1000;
+  return { kind: 'storage', item: s.item, name, ok, severity: 'fail',
+    expected: s.expect ?? null, because: s.because?.trim(),
+    detail: `${before} -> ${after}${ratio !== 1 ? `  (x${ratio.toExponential(3)})` : ''}` };
+}
+
+const check = (s, name, ok, detail) => ({
+  kind: 'storage', item: s.item, name, ok, detail,
+  because: s.because?.trim(), expected: s.expect ?? null,
+  severity: 'fail',
+});

--- a/tools/migration-eval/src/engine.mjs
+++ b/tools/migration-eval/src/engine.mjs
@@ -1,10 +1,38 @@
 import { ApiPromise, WsProvider } from '@polkadot/api';
+import { xxhashAsU8a, } from '@polkadot/util-crypto';
+import { u8aConcat, u8aToHex } from '@polkadot/util';
 
 export const connect = (url) =>
   ApiPromise.create({ provider: new WsProvider(url, 2500, {}, 900000), noInitWarn: true });
 
 const split = (spec) => { const [p, i] = spec.split('::'); return [lower(p), lower(i)]; };
 const lower = (s) => s.charAt(0).toLowerCase() + s.slice(1);
+
+/**
+ * Count keys under a storage prefix by raw hash, bypassing metadata entirely.
+ *
+ * Needed because a migration that renames a storage item leaves the OLD prefix
+ * absent from post-upgrade metadata — so a metadata-driven query cannot tell
+ * "the prefix is empty" from "the item no longer exists". Data orphaned under a
+ * dead prefix is invisible to `capture()` and visible here.
+ */
+export async function countRawPrefix(api, spec) {
+  const [pallet, item] = spec.split('::');
+  const prefix = api.query[lower(pallet)]?.[lower(item)]?.keyPrefix?.();
+  // If the item is gone from metadata, derive the prefix from the names instead.
+  const hex = prefix
+    ? prefix.toHex()
+    : u8aToHex(u8aConcat(xxhashAsU8a(pallet, 128), xxhashAsU8a(item, 128)));
+  let total = 0, start = undefined;
+  for (;;) {
+    const page = await api.rpc.state.getKeysPaged(hex, 1000, start);
+    if (!page.length) break;
+    total += page.length;
+    start = page[page.length - 1].toHex();
+    if (page.length < 1000) break;
+  }
+  return total;
+}
 
 /**
  * Snapshot named storage items, decoded with whatever metadata the connection
@@ -68,8 +96,9 @@ export async function drive(api, { maxBlocks = 400 } = {}) {
   return { maxBlock, blocks, terminated: done };
 }
 
-/** Evaluate the scenario's assertions against before/after captures. */
-export function evaluate(scenario, before, after, run) {
+/** Evaluate the scenario's assertions against before/after captures.
+ *  `raw` holds raw-prefix key counts for items asserted with `rawCount:`. */
+export function evaluate(scenario, before, after, run, raw = {}) {
   const results = [];
   const a = scenario.assert ?? {};
 
@@ -96,6 +125,12 @@ export function evaluate(scenario, before, after, run) {
     if (s.sum?.unchanged) {
       const b = sumField(bef, s.sum.field), f = sumField(aft, s.sum.field);
       results.push(sumResult(s, `sum(${s.sum.field}) unchanged`, b, f, b !== null && b === f));
+    }
+    if (s.rawCount?.equals !== undefined) {
+      const got = raw[s.item];
+      results.push(check(s, `raw prefix key count == ${s.rawCount.equals}`,
+        got === s.rawCount.equals,
+        `${got} keys under twox128 prefix${got === s.rawCount.equals ? '' : ' — data orphaned under a prefix the runtime no longer declares'}`));
     }
     if (s.sum?.equalsBefore) {
       const b = sumField(before[s.sum.equalsBefore.item], s.sum.equalsBefore.field);

--- a/tools/migration-eval/src/fork.mjs
+++ b/tools/migration-eval/src/fork.mjs
@@ -10,7 +10,13 @@ const toolDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 /** Verify the candidate wasm is the artifact the scenario expects. */
 export function checkRuntime(scenarioPath, runtime) {
-  const wasm = resolve(dirname(scenarioPath), runtime.wasm);
+  // MIGRATION_EVAL_WASM points a scenario at a build outside the default target
+  // dir (a second worktree, a shared CARGO_TARGET_DIR) without editing — and so
+  // forking — the scenario file. Announced, never silent: evaluating a different
+  // artifact than the scenario names must be visible in the log.
+  const override = process.env.MIGRATION_EVAL_WASM;
+  const wasm = override ? resolve(override) : resolve(dirname(scenarioPath), runtime.wasm);
+  if (override) console.log(`  NOTE      wasm overridden by MIGRATION_EVAL_WASM, not the scenario's path`);
   if (!existsSync(wasm)) throw new Error(`runtime wasm not found: ${wasm}\nBuild it first: cargo build --release -p cere-runtime`);
   const bytes = readFileSync(wasm);
   const sha = createHash('sha256').update(bytes).digest('hex');

--- a/tools/migration-eval/src/fork.mjs
+++ b/tools/migration-eval/src/fork.mjs
@@ -17,7 +17,37 @@ export function checkRuntime(scenarioPath, runtime) {
   if (runtime.sha256 && runtime.sha256 !== sha) {
     throw new Error(`runtime sha256 mismatch\n  scenario expects ${runtime.sha256}\n  artifact is       ${sha}\nRefusing to evaluate a runtime the scenario was not written for.`);
   }
-  return { wasm, sha, bytes };
+
+  const deps = readWasmDeps(wasm);
+  for (const [crate, want] of Object.entries(runtime.deps ?? {})) {
+    const got = deps[crate];
+    if (!got) throw new Error(`scenario pins ${crate}, but it is not in the wasm build's lock file`);
+    if (!got.rev.startsWith(want))
+      throw new Error(
+        `${crate} revision mismatch\n  scenario expects ${want}\n  wasm was built from ${got.rev} (branch ${got.branch})\n` +
+        `Rebuild with WASM_BUILD_WORKSPACE_HINT set to the workspace root — wasm-builder\n` +
+        `resolves dependencies through its own lock file, which can diverge from the workspace's.`);
+  }
+  return { wasm, sha, bytes, deps };
+}
+
+/**
+ * Read the git revisions actually compiled into the wasm.
+ *
+ * substrate-wasm-builder runs a nested cargo build with its OWN Cargo.lock,
+ * written beside the artifact. If it cannot find the workspace lock it generates
+ * one independently, which can pin different revisions than the workspace —
+ * silently producing a wasm built from stale sources while the native build uses
+ * current ones. `sha256` cannot catch that: it proves you tested the artifact you
+ * named, not that the artifact came from the sources you think.
+ */
+export function readWasmDeps(wasmPath) {
+  const lock = resolve(dirname(wasmPath), 'Cargo.lock');
+  if (!existsSync(lock)) return {};
+  const out = {};
+  for (const m of readFileSync(lock, 'utf8').matchAll(/source = "git\+[^"]*\/([a-z0-9-]+)\.git\?branch=([^#"]+)#([0-9a-f]+)"/g))
+    out[m[1]] = { branch: m[2], rev: m[3] };
+  return out;
 }
 
 /**

--- a/tools/migration-eval/src/fork.mjs
+++ b/tools/migration-eval/src/fork.mjs
@@ -1,0 +1,54 @@
+import { spawn } from 'node:child_process';
+import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** The tool's own directory — chopsticks must run here to resolve its package,
+ *  and its working files belong here (gitignored), not next to the scenario. */
+const toolDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Verify the candidate wasm is the artifact the scenario expects. */
+export function checkRuntime(scenarioPath, runtime) {
+  const wasm = resolve(dirname(scenarioPath), runtime.wasm);
+  if (!existsSync(wasm)) throw new Error(`runtime wasm not found: ${wasm}\nBuild it first: cargo build --release -p cere-runtime`);
+  const bytes = readFileSync(wasm);
+  const sha = createHash('sha256').update(bytes).digest('hex');
+  if (runtime.sha256 && runtime.sha256 !== sha) {
+    throw new Error(`runtime sha256 mismatch\n  scenario expects ${runtime.sha256}\n  artifact is       ${sha}\nRefusing to evaluate a runtime the scenario was not written for.`);
+  }
+  return { wasm, sha, bytes };
+}
+
+/**
+ * Start Chopsticks WITHOUT the wasm override, so the first capture sees
+ * pre-upgrade metadata. The candidate runtime is applied later, by writing
+ * `:code`, which is what makes on_runtime_upgrade fire on the next block.
+ */
+export async function startFork(fork, port = 8011) {
+  const cfg = resolve(toolDir, '.chopsticks.yml');
+  writeFileSync(cfg, [
+    `endpoint: ${fork.endpoint}`,
+    fork.at && fork.at !== 'latest' ? `block: ${fork.at}` : null,
+    'mock-signature-host: true',
+    `allow-unresolved-imports: ${fork.allowUnresolvedImports ? 'true' : 'false'}`,
+    `rpc-timeout: ${fork.rpcTimeout ?? 600000}`,
+    `port: ${port}`,
+    `db: ${resolve(toolDir, '.chopsticks.sqlite')}`,
+    fork.prefetch?.length ? 'prefetch-storages:' : null,
+    ...(fork.prefetch ?? []).map((p) => `  - ${p}`),
+  ].filter(Boolean).join('\n') + '\n');
+
+  const proc = spawn('npx', ['chopsticks', '--config', cfg], { cwd: toolDir, stdio: ['ignore', 'pipe', 'pipe'] });
+  let log = '';
+  const ready = new Promise((res, rej) => {
+    const t = setTimeout(() => rej(new Error(`chopsticks did not become ready in 300s\n${tail(log)}`)), 300000);
+    const scan = (d) => { log += d; if (String(d).includes('listening on')) { clearTimeout(t); res(); } };
+    proc.stdout.on('data', scan); proc.stderr.on('data', scan);
+    proc.on('exit', (c) => { clearTimeout(t); rej(new Error(`chopsticks exited with ${c}\n${tail(log)}`)); });
+  });
+  await ready;
+  return { proc, url: `ws://localhost:${port}` };
+}
+
+const tail = (s, n = 25) => s.trim().split('\n').slice(-n).map((l) => '    | ' + l).join('\n');


### PR DESCRIPTION
## What this is

A harness that evaluates a candidate runtime's storage migrations against **real chain state**, asserting that values still *mean the same thing* afterwards.

No runtime code is touched. Reviewable and mergeable independently of the port and the migration fixes.

## Why it exists

Migration bugs on this chain do not look like crashes. They look like success.

Evaluation round 1 found `ddc-payouts` v2 skipping all 58 Mainnet billing reports — `translate` skips undecodable entries rather than deleting them — and then `v3` reading those same untouched bytes as `v2::BillingReport`, **which is also exactly 167 bytes**. The decode succeeds against a misaligned layout and writes rewards inflated by ~4.2e12× into `PayoutReceipts`, permanently.

try-runtime reported no error. The migration's own `pre_upgrade` and `post_upgrade` both count `v1::ActiveBillingReports::iter()`, and `PrefixIterator` skips undecodable entries by the same rule — so `ensure!(prev_count == post_count)` compared `0 == 0` and passed.

**A harness that asks "did it error?" ships that.** This one compares decoded values before and after.

## How it works

1. Fork with Chopsticks **without** the candidate runtime, so the first capture decodes with pre-upgrade metadata
2. Snapshot the items named under `capture:`
3. Write the candidate wasm to `:code` — `on_runtime_upgrade` fires on the next block, as from a real `set_code`
4. Drive blocks until `MultiBlockMigrations::Cursor` clears, recording per-block weight and events. Capped, so a non-terminating MBM fails loudly rather than hanging
5. Reconnect for post-upgrade metadata, snapshot again
6. Evaluate assertions across both snapshots

Steps 1 and 5 are the mechanism: the same bytes under two type universes is what makes a misaligned-layout migration visible at all. Decoding comes from runtime metadata, so there are no hand-written decoders to drift.

## Current output

`scenarios/mainnet-release-1.yml` run against the port branch's runtime:

As first written, against the port branch's runtime:

```
6 passed, 3 failed  (3 known, 0 unexpected)

FAIL (known)  DdcCustomers::ClusterLedger count == 535        count=0
FAIL (known)  DdcCustomers::Ledger count == 0                 still present
FAIL (known)  PayoutReceipts sum(total_distributed_rewards) preserved
              1078434586618 -> 2270775748729572094622377  (x2.106e+12)
```

**It has since proved itself.** ddc-payouts#79 landed a decode shim and self-gating guards for exactly the defect that last assertion describes. Re-running the unchanged scenario against a runtime carrying that fix:

```
7 passed, 2 failed  (2 known, 0 unexpected)

PASS  DdcPayouts::PayoutReceipts sum(total_distributed_rewards) preserved
      1078434586618 -> 1078434586618
```

Exactly preserved across all 58 records. The assertion was written from the round-1 findings **before** the fix existed, and flipped without being touched — which is the property this PR is arguing for.

Peak weight moved 81.19% → 82.93%, which is the fix doing real work: v2 now translates 58 records and writes 58 fingerprints instead of skipping them all.

**Still expected to land red.** The two remaining failures are `ddc-customers` `v4_mbm` — ledgers destroyed, and copy-without-remove — which PR C addresses.

Note the last line independently reproduces round 1's finding: that analysis hand-decoded one record in Python and measured 4.229e12× on one field. The tool, from runtime metadata and a declarative scenario, gets 2.106e12× across the aggregate of all 58 — same order, entirely different code path.

## Scenarios are specifications

A scenario states what a release **must** do, written from evaluation findings *before* the fix exists. `because:` is required prose explaining what each assertion protects, printed on failure, so a red run explains itself.

If a fix cannot satisfy an assertion and the assertion is changed instead, that appears as its own diff. **Treat that as a question, not a detail.**

The `Balances::Holds` assertion is a regression guard rather than a blocker: appending `DdcVerification` at index 54 instead of inserting at 40 is what keeps all 914 hold records — 17.16M CERE — decodable. That is now checked continuously rather than argued in a document.

## Two safeguards learned the hard way

Both are here because I hit them while building this:

- **`runtime.sha256`** lets a scenario refuse to run against an artifact it was not written for. A scenario was run against a stale wasm during development, and the unchanged result was briefly read as a fix failing to work.
- **`runtime.deps`** goes further, because `sha256` proves you evaluated the artifact you *named* — not that it was built from the sources you *think*. substrate-wasm-builder runs a nested cargo build with its own `Cargo.lock` beside the artifact; when it cannot find the workspace lock (announced only as a warning) it generates one independently. That produced `workspace: ddc-payouts#8178000c` against `wbuild: #b8988623` — the native build had the fix, the wasm did not, and the runtime hash was byte-identical across a real source change. The tool now reads that lock, prints every compiled-in revision, and can assert on them. `WASM_BUILD_WORKSPACE_HINT` is documented as required, not advisory.
- **A `sum:` whose field resolves on neither side reports `FIELD NOT FOUND — assertion proved nothing`**, never a value comparison. The first version matched snake_case against camelCase JSON and silently compared `null` to `null` — the same vacuous-check failure this tool exists to catch.

## Two non-obvious Chopsticks requirements

- `allowUnresolvedImports: true` — the runtime imports `ext_ddc_dac_close_session_version_1` from `ddc-dac-host`. Chopsticks provides only the standard host set, so without this it fails at instantiation. Unresolved imports then trap only if *called*; migrations touch storage, not DAC sessions. **A migration that calls a `ddc-dac-host` function cannot be evaluated here** — use try-runtime.
- `prefetch:` — lazy per-key fetching against a ~1s-per-call endpoint stalls block building past any sane RPC timeout.

## Usage

```bash
cargo build --release -p cere-runtime
cd tools/migration-eval && npm install
npm run eval -- scenarios/mainnet-release-1.yml
```

## Review guidance

224 lines across three modules — `fork.mjs` (Chopsticks lifecycle, wasm hash check), `engine.mjs` (capture, drive, assertions), `cli.mjs` (orchestration). The assertion semantics in `engine.mjs` are where the judgement is; the rest is plumbing.

## Related

- Port: #734
- Evaluation: `02-cere-protocol/blockchain/mainnet-storage-migration-evaluation.md` in the memory bank
- Migration fixes: to follow, in `ddc-payouts` and this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)