### PR TITLE
chore(deps): bump pallet-ddc-payouts for the era-milliseconds fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#2db3b22329d4dae117f74694b8823d3cc89cb9f5"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=dev#288def87922c76700d1946d18380d7499bcf3e52"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",


### PR DESCRIPTION
Picks up ddc-payouts#83 (`288def87`).

## What #83 fixes

`era.time_end` is already in milliseconds, but the rate lookup multiplied it by `1_000` as though it were seconds. That pushed the lookup to the year 58606, where `rate_at` rejected every entry as roughly 56,000 years stale — so every era came back `RateUnavailable` and **payouts halted outright**. #83 passes the value through unscaled via a new `era_end_moment` helper and renames `duration_seconds` to `duration_ms` in the proration.

## Scope

Lockfile only — a single line:

```
-…/ddc-payouts.git?branch=dev#2db3b22329d4dae117f74694b8823d3cc89cb9f5
+…/ddc-payouts.git?branch=dev#288def87922c76700d1946d18380d7499bcf3e52
```

One instance, `branch = "dev"`, and nothing else in `Cargo.lock` moved.

No runtime code changed. The `PriceProvider` signature is unchanged — still `fn current_rate() -> Option<(u128, u64)>` on both ddc-payouts `dev` and `staging` — so the `CereUsdRate` adapter in both runtimes needed no edit.

## RuntimeVersion

Unchanged: `spec_version 80016`, `transaction_version 27`, both runtimes. Devnet is live on 80015 and 80016 is not released yet, so it absorbs this change rather than needing its own bump.

## Gate

`cargo build --release` passes for `cere-runtime` and `cere-dev-runtime`.