### PR TITLE
fix(migrations): make release 1's migration set correct, and verify it against a Mainnet fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "pallet-ddc-payouts"
 version = "8.0.1"
-source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=mainnet-launch#7368b9e908851d2e7a10fd994b5e5b33aeed026c"
+source = "git+https://github.com/Cerebellum-Network/ddc-payouts.git?branch=mainnet-launch#8178000cd9a2549a204ef59e724aade1b6669f8f"
 dependencies = [
  "array-bytes 6.2.3",
  "byte-unit",

--- a/pallets/ddc-clusters/src/migrations.rs
+++ b/pallets/ddc-clusters/src/migrations.rs
@@ -459,7 +459,12 @@ pub mod v3 {
 			on_chain_version
 		);
 
-		if on_chain_version == 2 && current_version == 3 {
+		// `>=`, not `==`. The pallet declares STORAGE_VERSION = 6, so an equality
+		// test against 3 can never hold and this migration silently no-ops --
+		// leaving the chain at version 2 while the runtime decodes its storage as
+		// 6, and stalling v4/v5/v6 which each guard on the previous version. v3 is
+		// the first link, so the whole 2 -> 6 chain depends on this comparison.
+		if on_chain_version == 2 && current_version >= 3 {
 			let mut translated = 0u64;
 			let count = v2::Clusters::<T>::iter().count();
 			info!(

--- a/pallets/ddc-customers/src/migrations.rs
+++ b/pallets/ddc-customers/src/migrations.rs
@@ -740,7 +740,7 @@ pub mod v4_mbm {
 						Self::ledgers_step(Some(maybe_last_ledger), Some(maybe_cluster_id))
 					},
 					Some(MigrationState::TransferringBalance(cluster_id)) => {
-						Self::transfer_balance_step(cluster_id)
+						Self::transfer_balance_step(cluster_id)?
 					},
 					Some(MigrationState::Finished) => {
 						StorageVersion::new(Self::id().version_to as u16).put::<Pallet<T>>();
@@ -872,15 +872,29 @@ pub mod v4_mbm {
 
 			if let Some((key, ledger)) = iter.next() {
 				ClusterLedger::<T>::insert(cluster_id, key.clone(), ledger);
+				// Remove the source entry. Without this the migration only
+				// COPIES: every ledger stays under `DdcCustomers::Ledger`, a
+				// prefix the post-migration runtime no longer declares, so the
+				// data is orphaned where nothing will ever read it again and no
+				// metadata-driven query can even see it.
+				v4_mbm::Ledger::<T>::remove(&key);
 				MigrationState::MigratingLedgers(key, cluster_id)
 			} else {
 				MigrationState::TransferringBalance(cluster_id)
 			}
 		}
 
+		/// Sweep the pallet account into the cluster vault.
+		///
+		/// Returns `Err` on failure rather than logging and continuing. The
+		/// previous behaviour advanced to `Finished` regardless, which bumped
+		/// the storage version with the customer deposits still sitting in the
+		/// pallet account -- a migration reporting success having moved no
+		/// money. `FailedMigrationHandler` is `FreezeChainOnFailedMigration`, so
+		/// failing here halts rather than proceeding on false state.
 		pub(crate) fn transfer_balance_step(
 			cluster_id: &ClusterId,
-		) -> MigrationState<T::AccountId> {
+		) -> Result<MigrationState<T::AccountId>, SteppedMigrationError> {
 			let pallet_account_id = crate::Pallet::<T>::pallet_account_id();
 			let cluster_vault_id = crate::Pallet::<T>::cluster_vault_id(cluster_id);
 
@@ -893,7 +907,12 @@ pub mod v4_mbm {
 					pallet_balance,
 					ExistenceRequirement::AllowDeath,
 				) {
-					log::error!("❌ Error transferring balance: {:?}. Resolve this issue manually after the migration.", e);
+					log::error!(
+						"❌ Error transferring {:?} from pallet {:?} to cluster vault {:?}: {:?}. \
+						 Failing the migration rather than advancing with the deposits unmoved.",
+						pallet_balance, pallet_account_id, cluster_vault_id, e
+					);
+					return Err(SteppedMigrationError::Failed);
 				} else {
 					log::info!(
 						"✅ Successfully transferred {:?} tokens from pallet {:?} to cluster vault {:?}",
@@ -904,7 +923,7 @@ pub mod v4_mbm {
 				}
 			}
 
-			MigrationState::Finished
+			Ok(MigrationState::Finished)
 		}
 
 		pub(crate) fn required_weight(step: &MigrationState<T::AccountId>) -> Weight {

--- a/runtime/cere/src/lib.rs
+++ b/runtime/cere/src/lib.rs
@@ -1614,7 +1614,7 @@ parameter_types! {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = ();
+	type Migrations = migrations::UnreleasedMultiblock;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
 	type CursorMaxLen = ConstU32<65_536>;
@@ -1895,6 +1895,7 @@ type Migrations = (
 		Runtime,
 		polkadot_sdk::pallet_staking::migrations::v17::MigrateDisabledToSession<Runtime>,
 	>,
+	migrations::Unreleased,
 );
 // Migrations for the DDC pallets, unreleased to Mainnet.
 //
@@ -1927,16 +1928,31 @@ pub mod migrations {
 		// removal of `total_usage` field as it was never deployed on MAINNET
 		// pallet_ddc_verification::migrations::v3::MigrateToV3<Runtime>, // ignore as the
 		// `ddc-verification` pallet was never deployed on MAINNET
-		// pallet_ddc_nodes::migrations::v0_v2::MigrateFromV0ToV2<Runtime>,
+		// Mainnet's DdcNodes storage version key is absent, ie. 0, while the
+		// pallet declares 2. StorageNode and StorageNodeProps are unchanged
+		// between the two refs apart from an append-only StorageNodeMode variant,
+		// so v1 (which added total_usage) and v2_mbm (which removed it) net out on
+		// a chain that had neither. v0_v2 bumps 0 -> 2 and touches no data.
+		// Without it the version counter lies, and the next migration guarding on
+		// `on_chain == 2` would silently skip.
+		pallet_ddc_nodes::migrations::v0_v2::MigrateFromV0ToV2<Runtime>,
 		pallet_ddc_clusters::migrations::v4::MigrateToV4<Runtime>,
 		pallet_ddc_clusters::migrations::v5::MigrateToV5<Runtime>,
 		pallet_ddc_clusters::migrations::v6::MigrateToV6<Runtime>,
 	);
 
-	pub type UnreleasedMultiblock = (
-		pallet_ddc_customers::migrations::v4_mbm::LazyMigrationV3ToV4<Runtime>,
-		pallet_ddc_customers::migrations::v5_mbm::LazyMigrationV4ToV5<Runtime>,
-	);
+	// Release 1 stops at customers v4.
+	//
+	// v5_mbm drains ClusterLedger into a per-cluster deposit contract. Mainnet has
+	// no contracts at all -- Contracts::ContractInfoOf, CodeInfoOf and
+	// PristineCode are all empty -- and the address it reads from
+	// ClustersGovParams.customer_deposit_contract cannot be bound until a
+	// referendum sets it. Wiring it now empties all 535 ledgers into nothing.
+	//
+	// v4 leaves storage coherent at version 4, so v5 ships separately once the
+	// contract is live. See docs/MAINNET_LAUNCH_PORT_RECORD.md.
+	pub type UnreleasedMultiblock =
+		(pallet_ddc_customers::migrations::v4_mbm::LazyMigrationV3ToV4<Runtime>,);
 }
 
 


### PR DESCRIPTION
Release 1's migration set was wired incorrectly and contained two data-loss
defects. This makes it correct, and verifies the result against a fork of
Mainnet at #26866694.

Stacked on #734 (`feat/port-pallets`), which is still open — review that first.

## What was wrong

**1. `ddc-customers` v4 MBM copied without removing.** `ledgers_step` inserted
into `ClusterLedger` but never removed the source entry, stranding all 535
`Ledger` entries under the old prefix. Nothing reads them and nothing reports
them — the migration looks complete and the count under the new key is right.

**2. A failed balance transfer in `transfer_balance_step` was swallowed.** It
returned the next state regardless, so a transfer failure advanced the state
machine and the migration reported success having moved no funds. It now
returns `Err(SteppedMigrationError::Failed)`, which the runtime's
`FreezeChainOnFailedMigration` turns into a halt rather than silent loss.

**3. `UnreleasedMultiblock` included customers v5.** v5 belongs to release 2
(it needs the deposit contract). Worse, v5 *drains* what v4 fills, so running
both left `ClusterLedger` empty. Scoped to v4 only.

**4. Neither list was wired.** `Unreleased` and `UnreleasedMultiblock` existed
but nothing referenced them, so no migration ran at all.

**5. `ddc-clusters` v3 guard was unsatisfiable.** `on_chain == 2 && current == 3`
can never hold — the pallet declares `STORAGE_VERSION = 6`. Now `current >= 3`.

**6. `ddc-nodes` v0→v2 was disabled.** Mainnet's `DdcNodes` version key is
absent (0) while the pallet declares 2. v1 added `total_usage` and v2 removed
it, so they net out on a chain that had neither; `v0_v2` bumps the counter and
touches no data. Without it the counter lies and the next version-guarded
migration silently skips.

Also pulls `ddc-payouts` `8178000c` into the lock, which carries the payouts
v1–v5 decode fixes. `v1::CustomerCharge` and its successor differ by one field
but both encode to 167 bytes, so the old code decoded misaligned bytes cleanly
and inflated reward totals ~2.1e12x — no error, just wrong numbers.

## Verification

Forked Mainnet at #26866694, applied the candidate runtime via `:code`, drove
blocks until the MBM cursor cleared. **No Mainnet state was touched.**

```
PASS  spec_version bumped                    73158 -> 73159
PASS  peakBlock <100%                        11.79% of maxBlock
PASS  ClusterLedger count == 535             535
PASS  Ledger raw prefix key count == 0       0 keys
PASS  Buckets count unchanged                1398 -> 1398
PASS  PayoutReceipts count == 58             58
PASS  PayoutReceipts reward sum preserved    1078434586618 -> 1078434586618
PASS  Balances::Holds count unchanged        914 -> 914
PASS  Balances::Holds sum unchanged          6808569242525748249
10 passed, 0 failed
```

The MBM completes inside the upgrade block at 11.79% of block capacity, leaving
~88% for extrinsics. Earlier runs needed two blocks and peaked at 81.19%; the
drop is v5's removal, not an optimisation.

`Balances::Holds` is asserted because `RuntimeHoldReason`'s outer SCALE variant
is the pallet index. Appending `DdcVerification` rather than inserting it keeps
all 914 entries decodable — inserting would have silently zeroed 17.16M CERE
of holds, since the storage item is `ValueQuery` and a failed decode returns
`Default` rather than erroring.

**Reproducing this requires both this branch and `feat/migration-eval-tool`
(#737) checked out together** — the harness lives on that branch and the fixes
on this one, so neither alone can produce the result above:

```bash
git checkout feat/migration-eval-tool -- tools/
WASM_BUILD_WORKSPACE_HINT="$PWD" cargo build --release -p cere-runtime
cd tools/migration-eval && npm install
npm run eval -- scenarios/mainnet-release-1.yml
```

## Open question, not addressed here

`runtime/cere-dev` has `type Migrations = ()` for MBMs and a `Migrations` tuple
containing only the two `RemovePallet`s — none of the DDC migrations above. So
dev/QA chains running `cere-dev` will not apply them, and their DDC storage
version counters will disagree with what the pallets declare. That may be
deliberate (those chains may already be migrated via the staging line, or get
reset), but the port record does not say, and it is outside this PR's
Mainnet-release-1 scope. Flagging rather than guessing.

## Out of scope

- customers v4→v5, the deposit contract, and the referendum — release 2
- re-adding `DdcVerification` and restoring `UpgradeSessionKeys` — release 3
