### PR TITLE
ci(try-runtime): snapshot-cached per-network checks

### DIFF
--- a/.github/workflows/check-try-runtime.yaml
+++ b/.github/workflows/check-try-runtime.yaml
@@ -42,6 +42,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Pick network and runtime
         id: target

--- a/.github/workflows/check-try-runtime.yaml
+++ b/.github/workflows/check-try-runtime.yaml
@@ -1,0 +1,125 @@
+name: Try-Runtime Check
+
+# Dry-runs the runtime upgrade against real chain state. The target is derived
+# from the PR's base branch rather than hardcoded, so dev and staging can share
+# one identical ci.yaml: a PR into staging is checked against testnet with the
+# cere runtime, anything else against devnet with the cere-dev runtime.
+#
+# State comes from the snapshot cached by "Refresh Try-Runtime Snapshots".
+# Missing snapshot is not fatal — the check falls back to streaming `live`,
+# which is correct but slow.
+
+on:
+  pull_request:
+    branches: [dev, staging]
+    paths:
+      - 'runtime/**'
+      - 'pallets/**'
+      - 'node/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - '.github/workflows/check-try-runtime.yaml'
+  workflow_dispatch:
+
+env:
+  # Feed the GH_READ_TOKEN rewrite to git through its environment form rather
+  # than `git config --global`, matching ci.yaml.
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: url.https://${{ secrets.GH_READ_TOKEN }}:x-oauth-basic@github.com/.insteadOf
+  GIT_CONFIG_VALUE_0: https://github.com/
+
+concurrency:
+  group: try-runtime-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-try-runtime:
+    name: Try-Runtime Check
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pick network and runtime
+        id: target
+        run: |
+          if [ "${{ github.base_ref }}" = "staging" ]; then
+            {
+              echo "uri=wss://archive.testnet.cere.network:443"
+              echo "wasm=./target/release/wbuild/cere-runtime/cere_runtime.compact.compressed.wasm"
+              echo "package=cere-runtime"
+              echo "network=testnet"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "uri=wss://archive.devnet.cere.network:443"
+              echo "wasm=./target/release/wbuild/cere-dev-runtime/cere_dev_runtime.compact.compressed.wasm"
+              echo "package=cere-dev-runtime"
+              echo "network=devnet"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Date stamp
+        id: date
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Install linux dependencies
+        run: sudo apt update && sudo apt install -y clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
+
+      - name: Install toolchain and rust-src
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.91.0
+          target: wasm32-unknown-unknown
+          components: rust-src
+          cache: false
+          rustflags: ""
+
+      - name: Enhanced Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "runtime-build-${{ steps.target.outputs.package }}"
+          cache-on-failure: true
+
+      - name: Cache try-runtime binary
+        id: trycli-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/try-runtime
+          key: try-runtime-cli-v0.8.0-${{ runner.os }}
+
+      - name: Install try-runtime
+        if: steps.trycli-cache.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.8.0 --locked
+
+      - name: Restore latest ${{ steps.target.outputs.network }} snapshot
+        id: snap
+        uses: actions/cache/restore@v4
+        with:
+          path: snapshots/${{ steps.target.outputs.network }}.snap
+          key: try-runtime-snap-${{ steps.target.outputs.network }}-${{ steps.date.outputs.today }}
+          restore-keys: |
+            try-runtime-snap-${{ steps.target.outputs.network }}-
+
+      - name: Build runtime for try-runtime
+        run: |
+          CARGO_INCREMENTAL=1 cargo build --release --features try-runtime --package ${{ steps.target.outputs.package }}
+
+      - name: Check Try-Runtime
+        run: |
+          SNAP_PATH=snapshots/${{ steps.target.outputs.network }}.snap
+          if [ -f "$SNAP_PATH" ]; then
+            echo "Using cached snapshot (matched key: ${{ steps.snap.outputs.cache-matched-key }})"
+            try-runtime --runtime ${{ steps.target.outputs.wasm }} \
+              on-runtime-upgrade --disable-idempotency-checks --disable-spec-version-check --blocktime 6000 \
+              snap --path "$SNAP_PATH"
+          else
+            echo "No snapshot in cache for ${{ steps.target.outputs.network }} — falling back to live."
+            echo "Run the 'Refresh Try-Runtime Snapshots' workflow to populate the cache."
+            try-runtime --runtime ${{ steps.target.outputs.wasm }} \
+              on-runtime-upgrade --disable-idempotency-checks --disable-spec-version-check --blocktime 6000 \
+              live --uri ${{ steps.target.outputs.uri }}
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,37 +102,6 @@ jobs:
           cargo build --release --bin cere
           timeout --preserve-status 30s ./target/release/cere --dev
 
-  check-try-runtime:
-    name: Try-Runtime Check
-    needs: format
-    runs-on: ubuntu-24.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Install linux dependencies
-        run: sudo apt update && sudo apt install -y clang libclang-dev libssl-dev llvm libudev-dev protobuf-compiler
-      - name: Install toolchain and rust-src
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.91.0
-          targets: wasm32-unknown-unknown
-          components: rust-src
-      - name: Enhanced Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "runtime-build"
-          cache-on-failure: true
-      - name: Install try-runtime
-        run: cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.8.0 --locked
-      - name: Build for try-runtime
-        run: |
-          CARGO_INCREMENTAL=1 cargo build --release --features try-runtime
-      - name: Check Try-Runtime
-        run: |
-          try-runtime --runtime ./target/release/wbuild/cere-dev-runtime/cere_dev_runtime.compact.compressed.wasm \
-          on-runtime-upgrade --disable-idempotency-checks --blocktime 6000 live --uri wss://archive.devnet.cere.network:443
 
   clippy:
     name: Run Clippy

--- a/.github/workflows/snapshot-try-runtime.yaml
+++ b/.github/workflows/snapshot-try-runtime.yaml
@@ -1,0 +1,95 @@
+name: Refresh Try-Runtime Snapshots
+
+# Pulls a full state snapshot per network and parks it in the Actions cache so
+# the per-PR try-runtime check does not have to stream the chain itself. The
+# check falls back to `live` when no snapshot is cached, so this workflow is a
+# speed-up, never a hard dependency.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network to snapshot'
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - devnet
+          - testnet
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    name: Snapshot ${{ matrix.network }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - network: devnet
+            uri: wss://archive.devnet.cere.network:443
+          - network: testnet
+            uri: wss://archive.testnet.cere.network:443
+    steps:
+      - name: Skip non-targeted network
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ "${{ inputs.network }}" != "all" ] \
+             && [ "${{ inputs.network }}" != "${{ matrix.network }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.network }} (dispatch targeted ${{ inputs.network }})"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.skip == 'false'
+
+      - name: Date stamp
+        id: date
+        if: steps.gate.outputs.skip == 'false'
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Install linux dependencies
+        if: steps.gate.outputs.skip == 'false'
+        run: sudo apt update && sudo apt install -y clang libclang-dev libssl-dev protobuf-compiler
+
+      - name: Install toolchain
+        if: steps.gate.outputs.skip == 'false'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.91.0
+          cache: false
+          rustflags: ""
+
+      - name: Cache try-runtime binary
+        id: trycli-cache
+        if: steps.gate.outputs.skip == 'false'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/try-runtime
+          key: try-runtime-cli-v0.8.0-${{ runner.os }}
+
+      - name: Install try-runtime
+        if: steps.gate.outputs.skip == 'false' && steps.trycli-cache.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --tag v0.8.0 --locked
+
+      - name: Create snapshot
+        if: steps.gate.outputs.skip == 'false'
+        run: |
+          mkdir -p snapshots
+          try-runtime create-snapshot --uri ${{ matrix.uri }} snapshots/${{ matrix.network }}.snap
+          ls -lh snapshots/
+
+      - name: Save snapshot to cache
+        if: steps.gate.outputs.skip == 'false'
+        uses: actions/cache/save@v4
+        with:
+          path: snapshots/${{ matrix.network }}.snap
+          key: try-runtime-snap-${{ matrix.network }}-${{ steps.date.outputs.today }}

--- a/.github/workflows/snapshot-try-runtime.yaml
+++ b/.github/workflows/snapshot-try-runtime.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - uses: actions/checkout@v4
         if: steps.gate.outputs.skip == 'false'
+        with:
+          submodules: true
 
       - name: Date stamp
         id: date


### PR DESCRIPTION
Ports the snapshot design from `feat/try-runtime-snapshot-caching`, which was validated there (snapshot ran green 05-19 and 05-22, check 05-20 and 05-23) but never merged. **Content ported, branch not merged** — it is 81 commits behind `dev` and carries unrelated drift.

The live check streams the whole chain on every PR, which is why it keeps getting cancelled around 67 minutes.

## The two workflows

**`snapshot-try-runtime.yaml`** — nightly cron `0 3 * * *`, plus dispatch with an `all`/`devnet`/`testnet` choice. Matrix over devnet + testnet, `try-runtime create-snapshot --uri <archive>`, saved to the Actions cache as `try-runtime-snap-<network>-<YYYY-MM-DD>`. The try-runtime binary is cached too.

**`check-try-runtime.yaml`** — on `pull_request` into `dev` or `staging`, path-filtered to `runtime/**`, `pallets/**`, `node/**`, `Cargo.*`. It derives network, package and wasm **from `github.base_ref`**:

| base | network | package |
|---|---|---|
| `staging` | testnet | `cere-runtime` |
| anything else | devnet | `cere-dev-runtime` |

That derivation is the point: **dev and staging can now share one identical `ci.yaml`**, with no hardcoded URI anywhere to diverge on. It restores the snapshot with a prefix `restore-keys` fallback so yesterday's snapshot still counts, builds only the one package it needs, and runs `snap --path` when a snapshot exists — falling back to `live --uri` when it does not. `continue-on-error: true`, per-PR concurrency with `cancel-in-progress`.

## Both TEMP blocks stripped

The author left two, both marked "remove before merging":

1. a `push:` trigger pinned to `branches: [feat/try-runtime-snapshot-caching]` — removed entirely; `pull_request` + `workflow_dispatch` remain.
2. `TEST_BASE_REF: staging` — removed, **along with the `[ -z "$BASE" ] && BASE="$TEST_BASE_REF"` line that read it**. Left in, that override would have forced every PR down the staging path. Zero references remain repo-wide.

## Modernised on the way through

The branch is three months stale:

- `actions-rs/toolchain@v1` → `actions-rust-lang/setup-rust-toolchain@v1` (`target` singular, no `override`), with `rustflags: ""` and `cache: false` pinned back — that action defaults to `-D warnings` and to running Swatinem itself.
- toolchain `1.90.0` → `1.91.0`
- the `Configure Git` `git config --global` step → the workflow-level `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` form `ci.yaml` already uses
- Debian's `cargo` dropped from the apt list, for the same reason it was dropped from `ci.yaml` — it makes `rustup-init` abort with `cannot install while Rust is installed`
- **kept**: `--disable-spec-version-check` (7436438d) and the protoc/build-deps install (70677500)

## ci.yaml

Its inline `check-try-runtime` job is removed — 31 lines, superseded. That job carried a hardcoded devnet URI; `ci.yaml` now has none, and 0 jobs invoking the try-runtime binary (down from 1).

## After merge — one manual step

Someone must dispatch **"Refresh Try-Runtime Snapshots"** once to seed the cache. Until then the check falls back to `live` and stays slow. It will not fail — the fallback is by design — it just will not be fast until a snapshot exists.